### PR TITLE
KULRICE-14151 fixed LibraryContainerDialogGroupAft and DemoDialogController

### DIFF
--- a/rice-framework/krad-sampleapp/web/src/it/java/org/kuali/rice/krad/demo/uif/library/containers/LibraryContainerDialogGroupAft.java
+++ b/rice-framework/krad-sampleapp/web/src/it/java/org/kuali/rice/krad/demo/uif/library/containers/LibraryContainerDialogGroupAft.java
@@ -117,6 +117,10 @@ public class LibraryContainerDialogGroupAft extends WebDriverLegacyITBase {
     protected void testContainerDialogGroupServerDialog1() throws Exception {
     	waitAndClickByLinkText("Server Dialog Ex. 1");
     	waitAndClickByXpath("//section[@id='Demo-DialogGroup-Example8']/button");
+        waitForProgressLoading();
+        waitAndClickByXpath(
+                "//section[@id='Demo-DialogGroup-ServerResponse1']/div/div/div[@data-parent='Demo-DialogGroup-ServerResponse1']/button[contains(text(),'Yes')]");
+        waitForElementPresentByXpath("//div[@id='Demo-DialogGroup-Example8_messages']/ul/li[contains(text(), 'Save was completed.')]");
     }
     
     protected void testContainerDialogGroupServerDialog2() throws Exception {

--- a/rice-framework/krad-sampleapp/web/src/main/java/org/kuali/rice/krad/demo/uif/controller/DemoDialogController.java
+++ b/rice-framework/krad-sampleapp/web/src/main/java/org/kuali/rice/krad/demo/uif/controller/DemoDialogController.java
@@ -15,9 +15,9 @@
  */
 package org.kuali.rice.krad.demo.uif.controller;
 
-import org.kuali.rice.krad.demo.uif.form.KradSampleAppForm;
 import org.kuali.rice.krad.util.GlobalVariables;
 import org.kuali.rice.krad.web.form.DialogResponse;
+import org.kuali.rice.krad.web.form.UifFormBase;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,7 +37,8 @@ public class DemoDialogController extends KradSampleAppController {
     protected static final String DEMO_DISAPPROVE_SURVEY = "Demo-DialogGroup-ServerResponse3";
 
     @RequestMapping(params = "methodToCall=save")
-    public ModelAndView save(@ModelAttribute("KualiForm") KradSampleAppForm form) throws Exception {
+    @Override
+    public ModelAndView save(@ModelAttribute("KualiForm") UifFormBase form) throws Exception {
         // typically there would be conditional logic that triggers the dialog
         DialogResponse duplicateDialogResponse = form.getDialogResponse(DEMO_DUPLICATE_DIALOG);
         if (duplicateDialogResponse == null) {
@@ -54,7 +55,7 @@ public class DemoDialogController extends KradSampleAppController {
     }
 
     @RequestMapping(params = "methodToCall=disapprove")
-    public ModelAndView disapprove(@ModelAttribute("KualiForm") KradSampleAppForm form) throws Exception {
+    public ModelAndView disapprove(@ModelAttribute("KualiForm") UifFormBase form) throws Exception {
         // typically there would be conditional logic that triggers the dialog
         DialogResponse disapproveConfirm = form.getDialogResponse(DEMO_DISAPPROVE_CONFIRM);
         if (disapproveConfirm == null) {

--- a/rice-tools-test/src/main/resources/JiraAwareContainsFailures.properties
+++ b/rice-tools-test/src/main/resources/JiraAwareContainsFailures.properties
@@ -22,9 +22,6 @@ detect\u0020tooltip=KULRICE-11866 AFT Failure UifTooltipAft figure out how to ve
 has\u0020a\u0020full\u0020lock:KULRICE-13330 AFT Failure DemoTravelAuthorizationPessimisticLockingAft.testPessimisticLockingOnRoute full lock is not present in CI
 'OK':KULRICE-13357 AFT Failures Dialogs on CI
 AddingNameSpace=KULRICE-13362 AFT Failure AddingNameSpace Back button fails on Saucelabs (which is currently running selenium 2.33.0) this should pass everywhere but Saucelabs
-Object\u0020for\u0020which\u0020expression\u0020is\u0020configured\u0020on\u0020is\u0020null\u0020or\u0020does\u0020not\u0020implement\u0020UifDictionaryBean:KULRICE-12758 AFT Failure RichMessages Incident Report Object for which expression is configured on is null or does not implement UifDictionaryBean: help.toolTip
 uif-breadcrumbSiblingLink']):KULRICE-13556 AFT Failures in CI that pass locally
 passes\u0020locally:KULRICE-13556 AFT Failures in CI that pass locally
 Demo404Aft:KULRICE-13912 AFT Failure Incident Report instead of 404 for bad urls
-LibraryContainerDialogGroupAft:KULRICE-14103 AFT Failure LibraryContainerDialogGroupAft testContainerDialogGroup reuse dialog delete IndexOutOfBoundsException
-DemoTravelCompanySuperUserTabAft:KULRICE-14107 AFT Failure DemoTravelCompanySuperUserTabAft User and Actions no longer displayed


### PR DESCRIPTION
Matches rice-2.5 pull request https://github.com/kuali/rice/pull/6

Fixed LibraryContainerDialogGroupAft, DemoDialogController (which actually caused a library demo not to work properly), and updated jira aware list
