### PR TITLE
KULRICE-14181: Don't cascade RouteNodeInstance branch deletion (all othe...

### DIFF
--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kew/engine/node/RouteNodeInstance.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kew/engine/node/RouteNodeInstance.java
@@ -69,7 +69,7 @@ public class RouteNodeInstance implements Serializable {
     @Column(name="DOC_HDR_ID")
 	private String documentId;
 
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne(cascade = {CascadeType.DETACH, CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH})
 	@JoinColumn(name="BRCH_ID")
 	private Branch branch;
 


### PR DESCRIPTION
...r operations cascade still). With Cascade.REMOVE (or Cascade.ALL), when the RouteNodeInstance is deleted, it will delete the branch associated with it, which causes all other route node instances under that branch to be deleted as well (instead of just the desired node instance and its future node instances).