### PR TITLE
KULRICE-14178 Updated master KRAD_Guide to match 2.5

### DIFF
--- a/src/site/docbook/KRAD_Guide/intro_to_uif.xml
+++ b/src/site/docbook/KRAD_Guide/intro_to_uif.xml
@@ -479,23 +479,23 @@
         <para>Now we can add static HTML content (just like creating an HTML page) along with
             dynamic content using the FreeMarker
             language:<programlisting linenumbering = "numbered">&lt;html>
-  &lt;head>&lt;title>\${KualiForm.title}&lt;/title>&lt;/head>
+  &lt;head>&lt;title>${KualiForm.title}&lt;/title>&lt;/head>
   &lt;body>
     &lt;table>
       &lt;tr>
-        &lt;td colspan="2">\${KualiForm.header}&lt;/td>
+        &lt;td colspan="2">${KualiForm.header}&lt;/td>
       &lt;/tr>
       &lt;tr>
-        &lt;td>\${menu}&lt;/td>
-        &lt;td>\${body}&lt;/td>
+        &lt;td>${menu}&lt;/td>
+        &lt;td>${body}&lt;/td>
       &lt;/tr>
       &lt;tr>
-        &lt;td colspan="2">\${KualiForm.footer}&lt;/td>
+        &lt;td colspan="2">${KualiForm.footer}&lt;/td>
       &lt;/tr>
     &lt;/table>
   &lt;/body>
 &lt;/html>     </programlisting></para>
-        <para>Notice within this file the use of '\${}' notation. This is known as an interpolation,
+        <para>Notice within this file the use of '${}' notation. This is known as an interpolation,
                 and is where data will be inserted. This data comes from a model we expose to
                 FreeMarker before rendering the templates. The model is a map of objects that can be
                 referenced within the FreeMarker templates. The map key gives the name by which the
@@ -530,26 +530,26 @@
             .ftl extension. Let's call this file body.ftl. Now we add the FreeMarker content to our
             template
             file:<programlisting linenumbering = "numbered">&lt;h2> This is the page body &lt;/h2>
-\${KualiForm.body}</programlisting></para>
+${KualiForm.body}</programlisting></para>
         <para>Next, we can bring in the contents of body.ftl into our main template by using the
             FreeMarker directive named <code>include</code>. To use the include directive we specify
             the absolute or relative path to the template file that should be included using the
             path
             attribute:<programlisting linenumbering = "numbered">&lt;html>
-  &lt;head>&lt;title>\${KualiForm.title}&lt;/title>&lt;/head>
+  &lt;head>&lt;title>${KualiForm.title}&lt;/title>&lt;/head>
   &lt;body>
     &lt;table>
       &lt;tr>
-        &lt;td colspan="2">\${KualiForm.header}&lt;/td>
+        &lt;td colspan="2">${KualiForm.header}&lt;/td>
       &lt;/tr>
       &lt;tr>
-        &lt;td>\${menu}&lt;/td>
+        &lt;td>${menu}&lt;/td>
         &lt;td>
            &lt;#include path="body.ftl"/>
         &lt;/td>
       &lt;/tr>
       &lt;tr>
-        &lt;td colspan="2">\${KualiForm.footer}&lt;/td>
+        &lt;td colspan="2">${KualiForm.footer}&lt;/td>
       &lt;/tr>
     &lt;/table>
   &lt;/body>
@@ -557,14 +557,14 @@
         <para>Interpolations may also contain expressions (see below). For example, we can add two
                 numeric properties together and render the result as follows:</para>
         <para>
-            <programlisting linenumbering = "numbered">\${KualiForm.numProp1 + KualiForm.numProp2}</programlisting>
+            <programlisting linenumbering = "numbered">${KualiForm.numProp1 + KualiForm.numProp2}</programlisting>
         </para>
         <para>With FreeMarker we are not limited to just reading properties from the model, but also
             may invoke methods! This is done using the method name within the expression, followed
             by list of values to send as parameters. The parameter values may reference another
             model property or variable:</para>
         <para>
-            <programlisting linenumbering = "numbered">\${KualiForm.retrieveTaxAmount(taxNumber, 'T')} </programlisting>
+            <programlisting linenumbering = "numbered">${KualiForm.retrieveTaxAmount(taxNumber, 'T')} </programlisting>
         </para>
         <para>In addition to accessing dynamic data within the model, we can create new dynamic
             variables within the template. To create a new variable the <code>assign</code>
@@ -572,8 +572,8 @@
             given separated by an
             equal:<programlisting linenumbering = "numbered">&lt;#assign myVar="Hello!"/></programlisting></para>
         <para>Similar to model properties, the value for a variable can be written to the output
-            stream using the \${}
-            notation:<programlisting linenumbering = "numbered">&lt;td>\${myVar}&lt;/td> &lt;#-- prints &lt;td>Hello!&lt;/td> --></programlisting></para>
+            stream using the ${}
+            notation:<programlisting linenumbering = "numbered">&lt;td>${myVar}&lt;/td> &lt;#-- prints &lt;td>Hello!&lt;/td> --></programlisting></para>
       
         <para>When assigning a variable value, we may also use an expression. Freemarker supports
                 all of the standard expression operators. The only notable difference is Freemarker
@@ -595,7 +595,7 @@
             <para>When a variable or property expression is null, by default FreeMarker will not
                 convert to an empty string but instead throw an exception. To prevent FreeMarker
                 from throwing an exception (and instead output nothing) an exclamation mark must be
-                added after the variable. For example: \${variable!}</para>
+                added after the variable. For example: ${variable!}</para>
         </tip>
     </section>
     
@@ -698,14 +698,14 @@ Correct Invocation:
             variable 'food':</para>
         <para>
             <programlisting linenumbering = "numbered">&lt;#list foods as food>
-  Name: \\${food.name}, Type: \\${food.type}
+  Name: ${food.name}, Type: ${food.type}
 &lt;/#list></programlisting>
         </para>
         <para>If the datatype to iterate over is a Map, we can iterate using the list directive to
             iterate over the keys of the map like the following example:</para>
         <para>
             <programlisting linenumbering = "numbered">&lt;#list map?keys as parm>
-  \${map[parm]}
+  ${map[parm]}
 &lt;/#list></programlisting>
         </para>
         <para>Here the loop variable gives the key for the map entry we are iterating over.</para>
@@ -717,7 +717,7 @@ Correct Invocation:
                 the following example demonistrates:</para>
         <para>
             <programlisting linenumbering = "numbered">&lt;#list seq as x>
-  \${x}
+  ${x}
   &lt;#if x = "spring">&lt;#break>&lt;/#if>
 &lt;/#list>    </programlisting>
         </para>
@@ -736,7 +736,7 @@ Correct Invocation:
                 body.ftl to become a macro as
                 follows:<programlisting linenumbering = "numbered">&lt;#macro body>
   &lt;h2> This is the page body &lt;/h2>
-  \${KualiForm.body}
+  ${KualiForm.body}
 &lt;/#macro></programlisting></para>
             <para>The name for the macro follows the #macro keyword. In this example we have named
                 our macro 'body'. Between the macro start and end tag we can add FreeMarker content
@@ -772,16 +772,16 @@ Correct Invocation:
   &lt;body>
     &lt;table>
       &lt;tr>
-        &lt;td colspan="2">\${header}&lt;/td>
+        &lt;td colspan="2">${header}&lt;/td>
       &lt;/tr>
       &lt;tr>
-        &lt;td>\${menu}&lt;/td>
+        &lt;td>${menu}&lt;/td>
         &lt;td>
-           \${bodyContent}
+           ${bodyContent}
         &lt;/td>
       &lt;/tr>
       &lt;tr>
-        &lt;td colspan="2">\${footer}&lt;/td>
+        &lt;td colspan="2">${footer}&lt;/td>
       &lt;/tr>
     &lt;/table>
   &lt;/body>  
@@ -789,7 +789,7 @@ Correct Invocation:
             </para>
             
             <para>Notice in this example we are writing out the values of the given macro parameters
-                using the \${} notation. Our body macro serves as a wrapper for the content.</para>
+                using the ${} notation. Our body macro serves as a wrapper for the content.</para>
             <para>For each macro parameter we can also specify whether a value is required to be
                 given by the caller, and if not a default value to use. A default value is indicated
                 by placing an equal sign after the parameter name, followed by the default value
@@ -858,9 +858,9 @@ Correct Invocation:
 Invocation:
 &lt;\@wrapTd>
   &lt;#if renderHeader>
-    \${header}
+    ${header}
   &lt;#else>
-    \${footer}
+    ${footer}
   &lt;/#if>
 &lt;/\@wrapTd></programlisting>
         </para>
@@ -877,7 +877,7 @@ Header One
         <para>
             <programlisting linenumbering = "numbered">&lt;#macro loop parms...>
   &lt;#list param.keys as key>
-    \${parm[key]}
+    ${parm[key]}
   &lt;/#list>
 &lt;#macro>
 
@@ -912,7 +912,7 @@ Invocation:
             values is done using function syntax '(parm1, parm2, ...)' rather than key/value pairs.
             The following shows examples of invoking the max function above:</para>
         <para>
-            <programlisting linenumbering = "numbered">\${max(number1, number2)}
+            <programlisting linenumbering = "numbered">${max(number1, number2)}
 &lt;#assign maxNum=max(number1, number2)/>
 &lt;#if number3 > max(number1, number2)>
    // block
@@ -932,14 +932,14 @@ Invocation:
             character ('?') after the variable (or expression), followed by the built-in name and
             any parameters. The following shows the general form:</para>
         <para>
-            <programlisting linenumbering = "numbered">\${someVariable?builtIn(parms)}</programlisting>
+            <programlisting linenumbering = "numbered">${someVariable?builtIn(parms)}</programlisting>
         </para>
         <para>The return value of the built-in invocation becomes the value for the
             expression:</para>
         <para>
             <programlisting linenumbering = "numbered">&lt;#assign name='Joe Smith'/>
-\${name} &lt;#-- prints 'Joe Smith' -->
-\${name?upper_case} &lt;#-- prints 'JOE SMITH' --></programlisting>
+${name} &lt;#-- prints 'Joe Smith' -->
+${name?upper_case} &lt;#-- prints 'JOE SMITH' --></programlisting>
         </para>
         <para> The following are other examples of built-ins provided.</para>
         <para><emphasis>String Built-Ins</emphasis></para>
@@ -1018,7 +1018,7 @@ Invocation:
             <title>Coarse-Grained Parameters</title>
             <para>An important consideration when setting up a macro is how to setup the parameters.
             To help explain this, let's take a look at a sample text
-            control:<programlisting linenumbering = "numbered">&lt;\@spring.input id="\${id}" path="\${path}" disabled="\${disabled}" size="\${size}" maxlength="\${maxLength}"/>    </programlisting></para>
+            control:<programlisting linenumbering = "numbered">&lt;\@spring.input id="${id}" path="${path}" disabled="${disabled}" size="${size}" maxlength="${maxLength}"/>    </programlisting></para>
             <para>This snippet is invoking a spring input macro, which will then output the HTML
                 input tag. We see some of the attributes this macro provides are id, path, disabled,
                 size, and maxlength. Since this template is generic (in the sense that it should
@@ -1027,18 +1027,18 @@ Invocation:
                 will allow values for these variables (or attributes) to be specified by the calling
                 template. This would look like the following:
                 <programlisting linenumbering = "numbered">&lt;#macro uif_input id path disabled size maxLength>
-  &lt;\@spring:input id="\${id}" path="\${path}" disabled="\${disabled}" size="\${size}" maxlength="\${maxLength}"/>  
+  &lt;\@spring:input id="${id}" path="${path}" disabled="${disabled}" size="${size}" maxlength="${maxLength}"/>  
 &lt;/#macro>  </programlisting></para>
             <para>The calling template would then be:
-            <programlisting linenumbering = "numbered">&lt;\@uif_input id="\${component.id}" path="\${component.path}" disabled="\${component.disabled}" 
-size="\${component.size}" maxLength="\${component.maxLength}"/>    </programlisting></para>
+            <programlisting linenumbering = "numbered">&lt;\@uif_input id="${component.id}" path="${component.path}" disabled="${component.disabled}" 
+size="${component.size}" maxLength="${component.maxLength}"/>    </programlisting></para>
             <para>Here the component variable is the component instance that has been exported to
                 the page. </para>
             <para>Now let's suppose that a developer wishes to override the component class and
             template to provide a 'readonly' property. The template now looks like this:
             <programlisting linenumbering = "numbered">&lt;#macro uif_input id path disabled size maxLength readOnly>
-  &lt;\@spring.input id="\${id}" path="\${path}" disabled="\${disabled}" size="\${size}" maxlength="\${maxLength}"
-    readOnly="\${readOnly}"/>  
+  &lt;\@spring.input id="${id}" path="${path}" disabled="${disabled}" size="${size}" maxlength="${maxLength}"
+    readOnly="${readOnly}"/>  
 &lt;/#macro>    </programlisting></para>
             <para>In order for the readonly attribute to be passed in, the developer must also
                 change the calling template and pass the corresponding component property value.
@@ -1048,13 +1048,13 @@ size="\${component.size}" maxLength="\${component.maxLength}"/>    </programlist
             individual properties of the component. Passing the full component makes changes our
             original macro to:
             <programlisting linenumbering = "numbered">&lt;#macro uif_input component>
-  &lt;\@spring.input id="\${component.id}" path="\${component.path}" disabled="\${component.disabled}" size="\${component.size}"/>
+  &lt;\@spring.input id="${component.id}" path="${component.path}" disabled="${component.disabled}" size="${component.size}"/>
 &lt;/#macro>    </programlisting></para>
             <para>Now for the custom template, we simply make use of the new property without any
             changes to the calling template:
             <programlisting linenumbering = "numbered">&lt;#macro uif_input component>
-  &lt;\@spring.input id="\${component.id}" path="\${component.path}" disabled="\${component.disabled}" size="\${component.size}"
-                 readOnly="\${component.readOnly}"/>
+  &lt;\@spring.input id="${component.id}" path="${component.path}" disabled="${component.disabled}" size="${component.size}"
+                 readOnly="${component.readOnly}"/>
 &lt;/#macro>    </programlisting></para>
             <para>In addition to providing more template flexibility, using the course grained
                 parameters gives us a uniform way of invoking templates (as we will see in a bit,
@@ -1205,7 +1205,7 @@ size="\${component.size}" maxLength="\${component.maxLength}"/>    </programlist
                     <para>Templates within KRAD are created using the FreeMarker framework.</para>
                 </listitem>
                 <listitem>
-                    <para>Within templates we can use the interpolation syntax '\${}' to output dynamic values.</para>
+                    <para>Within templates we can use the interpolation syntax '${}' to output dynamic values.</para>
                 </listitem>
                 <listitem>
                     <para>By default the UIF Form object, request object, user session, and configuration properties are made
@@ -1246,7 +1246,7 @@ size="\${component.size}" maxLength="\${component.maxLength}"/>    </programlist
                     parameter name. If a parameter does not have a default value defined it becomes a required parameter.</para>
                 </listitem>
                 <listitem>
-                    <para>Macros are invoked using the '' symbol followed by the macro name.
+                    <para>Macros are invoked using the '\@' symbol followed by the macro name.
                         Parameter values are given after the macro name with key=value pairs
                         (parameterName=parameterValue).</para>
                 </listitem>


### PR DESCRIPTION
I had extra escape characters in master that I don't need.  I went ahead and updated the version in master to match what is in rice-2.5.  Note that this is already running successfully in rice-2.5 reflected by our published documentation.