### PR TITLE
KULRICE-14124: Fixed an issue where returning a document to a previous node was causing an error when the document is at the final approval

### DIFF
--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kew/actionrequest/ActionRequestValue.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kew/actionrequest/ActionRequestValue.java
@@ -23,6 +23,7 @@ import org.kuali.rice.core.api.delegation.DelegationType;
 import org.kuali.rice.core.api.util.RiceConstants;
 import org.kuali.rice.kew.actionitem.ActionItem;
 import org.kuali.rice.kew.actiontaken.ActionTakenValue;
+import org.kuali.rice.kew.actiontaken.dao.impl.ActionTakenDaoJpa;
 import org.kuali.rice.kew.api.KewApiConstants;
 import org.kuali.rice.kew.api.action.ActionRequest;
 import org.kuali.rice.kew.api.action.ActionRequestPolicy;
@@ -82,7 +83,8 @@ import java.util.Map;
   @NamedQuery(name="ActionRequestValue.FindPendingByResponsibilityIds", query = "SELECT DISTINCT(arv.documentId) FROM ActionRequestValue arv WHERE (arv.status = '"
           + KewApiConstants.ActionRequestStatusVals.INITIALIZED + "' OR arv.status = '" +
                   KewApiConstants.ActionRequestStatusVals.ACTIVATED
-          + "') AND arv.responsibilityId IN :respIds")
+          + "') AND arv.responsibilityId IN :respIds"),
+  @NamedQuery(name = ActionTakenDaoJpa.FIND_ACTIONS_TAKEN_AT_NODE_INSTANCE_NAME, query = ActionTakenDaoJpa.FIND_ACTIONS_TAKEN_AT_NODE_INSTANCE_QUERY)
 })
 public class ActionRequestValue implements Serializable {
 

--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kew/actions/ReturnToPreviousNodeAction.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kew/actions/ReturnToPreviousNodeAction.java
@@ -382,10 +382,22 @@ public class ReturnToPreviousNodeAction extends ActionTakenEvent {
     private void assertFinalApprovalNodeNotInPath(List path) throws InvalidActionTakenException {
     	for (Iterator iterator = path.iterator(); iterator.hasNext(); ) {
 			RouteNodeInstance  nodeInstance = (RouteNodeInstance ) iterator.next();
-			// if we have a complete final approval node in our path, we cannot return past it
-			if (nodeInstance.isComplete() && Boolean.TRUE.equals(nodeInstance.getRouteNode().getFinalApprovalInd())) {
-				throw new InvalidActionTakenException("Cannot return past or through the final approval node '"+nodeInstance.getName()+"'.");
-			}
+            List<ActionTakenValue> actionsTaken = KEWServiceLocator.getActionTakenService().getActionsTakenAtRouteNode(nodeInstance);
+            ActionTakenValue foundValue =  null;
+            String actionTakenCode = null;
+            if(!actionsTaken.isEmpty()) {
+                foundValue = actionsTaken.get(0);
+            }
+            if(foundValue != null){
+                actionTakenCode = foundValue.getActionTaken();
+            }
+            if(actionTakenCode != null) {
+                // if we have a complete final approval node in our path and if the action taken at that node is not return to previous we cannot return past it
+                if (nodeInstance.isComplete() && Boolean.TRUE.equals(nodeInstance.getRouteNode().getFinalApprovalInd()) &&
+                        actionsTaken.isEmpty() && !actionTakenCode.equals(KewApiConstants.ACTION_TAKEN_RETURNED_TO_PREVIOUS_CD)) {
+                    throw new InvalidActionTakenException("Cannot return past or through the final approval node '" + nodeInstance.getName() + "'.");
+                }
+            }
 		}
     }
 

--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kew/actiontaken/dao/ActionTakenDao.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kew/actiontaken/dao/ActionTakenDao.java
@@ -17,9 +17,10 @@ package org.kuali.rice.kew.actiontaken.dao;
 
 import org.kuali.rice.kew.actiontaken.ActionTakenValue;
 import org.kuali.rice.kew.api.action.ActionType;
+import org.kuali.rice.kew.engine.node.RouteNodeInstance;
 
 import java.sql.Timestamp;
-
+import java.util.List;
 
 /**
  * Data Access Object for {@link ActionTakenValue}s.
@@ -43,5 +44,12 @@ public interface ActionTakenDao {
      * @throws IllegalArgumentException if documentId is null or blank, or if actionType is null
      */
     Timestamp getLastActionTakenDate(String documentId, ActionType actionType);
+
+    /**
+     * Returns the actions taken at a route node instance
+     * @param nodeInstance the route node instance
+     * @return the list of actions taken at a route node instance
+     */
+    List<ActionTakenValue> findActionsTakenAtRouteNodeInstance(RouteNodeInstance nodeInstance);
 
 }

--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kew/actiontaken/dao/impl/ActionTakenDaoJpa.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kew/actiontaken/dao/impl/ActionTakenDaoJpa.java
@@ -16,14 +16,16 @@
 package org.kuali.rice.kew.actiontaken.dao.impl;
 
 import org.apache.commons.lang.StringUtils;
+import org.kuali.rice.kew.actiontaken.ActionTakenValue;
 import org.kuali.rice.kew.actiontaken.dao.ActionTakenDao;
 import org.kuali.rice.kew.api.action.ActionType;
+import org.kuali.rice.kew.engine.node.RouteNodeInstance;
 
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.TypedQuery;
 import java.sql.Timestamp;
-
+import java.util.List;
 
 /**
  * JPA implementation of the {@link org.kuali.rice.kew.actiontaken.dao.ActionTakenDao}.
@@ -39,6 +41,9 @@ public class ActionTakenDaoJpa implements ActionTakenDao {
     public static final String GET_LAST_ACTION_TAKEN_DATE_NAME = "ActionTakenValue.getLastActionTakenDate";
     public static final String GET_LAST_ACTION_TAKEN_DATE_QUERY =
             "SELECT max(a.actionDate) from ActionTakenValue a where a.documentId = :documentId and a.actionTaken=:actionTaken";
+    public static final String FIND_ACTIONS_TAKEN_AT_NODE_INSTANCE_NAME = "ActionRequestValue.findActionsTakenAtRouteNodeInstance";
+    public static final String FIND_ACTIONS_TAKEN_AT_NODE_INSTANCE_QUERY =
+            "Select r.actionTaken from ActionRequestValue r where r.nodeInstance = :nodeInstance";
 
     public Timestamp getLastActionTakenDate(String documentId, ActionType actionType) {
         if (StringUtils.isBlank(documentId) || actionType == null) {
@@ -53,6 +58,14 @@ public class ActionTakenDaoJpa implements ActionTakenDao {
         } catch (NoResultException e) {
             return null;
         }
+    }
+
+    public List<ActionTakenValue> findActionsTakenAtRouteNodeInstance(RouteNodeInstance nodeInstance) {
+        TypedQuery<ActionTakenValue> query =
+                entityManager.createNamedQuery(FIND_ACTIONS_TAKEN_AT_NODE_INSTANCE_NAME, ActionTakenValue.class);
+        query.setParameter("nodeInstance", nodeInstance);
+
+        return query.getResultList();
     }
 
     public EntityManager getEntityManager() {

--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kew/actiontaken/service/ActionTakenService.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kew/actiontaken/service/ActionTakenService.java
@@ -17,6 +17,7 @@ package org.kuali.rice.kew.actiontaken.service;
 
 import org.kuali.rice.kew.actionrequest.ActionRequestValue;
 import org.kuali.rice.kew.actiontaken.ActionTakenValue;
+import org.kuali.rice.kew.engine.node.RouteNodeInstance;
 
 import java.sql.Timestamp;
 import java.util.Collection;
@@ -49,5 +50,12 @@ public interface ActionTakenService {
     boolean hasUserTakenAction(String principalId, String documentId);
 
     Timestamp getLastApprovedDate(String documentId);
+
+    /**
+     * Returns actions taken at a route node instance
+     * @param nodeInstance the route node instance
+     * @return actions taken at a route node instance
+     */
+    List<ActionTakenValue> getActionsTakenAtRouteNode(RouteNodeInstance nodeInstance);
 
 }

--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kew/actiontaken/service/impl/ActionTakenServiceImpl.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kew/actiontaken/service/impl/ActionTakenServiceImpl.java
@@ -24,6 +24,7 @@ import org.kuali.rice.kew.actiontaken.ActionTakenValue;
 import org.kuali.rice.kew.actiontaken.dao.ActionTakenDao;
 import org.kuali.rice.kew.actiontaken.service.ActionTakenService;
 import org.kuali.rice.kew.api.action.ActionType;
+import org.kuali.rice.kew.engine.node.RouteNodeInstance;
 import org.kuali.rice.kim.api.group.GroupService;
 import org.kuali.rice.kim.api.services.KimApiServiceLocator;
 import org.kuali.rice.krad.data.DataObjectService;
@@ -170,6 +171,11 @@ public class ActionTakenServiceImpl implements ActionTakenService {
         }
     }
 
+    @Override
+    public List<ActionTakenValue> getActionsTakenAtRouteNode(RouteNodeInstance nodeInstance) {
+
+        return getActionTakenDao().findActionsTakenAtRouteNodeInstance(nodeInstance);
+    }
 
     public ActionTakenDao getActionTakenDao() {
         return actionTakenDao;


### PR DESCRIPTION
* Fixed an issue where returning a document to a previous node was causing an error when the document is at the final approval node, even though no action was taken at that node.
* Added an IT to test the fix

Squashed version of pull request #63.