### PR TITLE
KULRICE-14144 fixed constraint orderding issue with impex dataset

### DIFF
--- a/db/sql/src/main/resources/org/kuali/rice/rice-sql/upgrades/2.6.0/mysql/server/bootstrap/2015-02-05--KULRICE-14144.sql
+++ b/db/sql/src/main/resources/org/kuali/rice/rice-sql/upgrades/2.6.0/mysql/server/bootstrap/2015-02-05--KULRICE-14144.sql
@@ -71,8 +71,6 @@ alter table krsb_qrtz_cron_triggers add column sched_name varchar(120) not null 
 /
 alter table krsb_qrtz_fired_triggers add column sched_name varchar(120) not null DEFAULT 'KrTestScheduler'
 /
-alter TABLE krsb_qrtz_fired_triggers add COLUMN SCHED_TIME BIGINT(13) NOT NULL
-/
 alter table krsb_qrtz_job_details add column sched_name varchar(120) not null DEFAULT 'KrTestScheduler'
 /
 alter table krsb_qrtz_locks add column sched_name varchar(120) not null DEFAULT 'KrTestScheduler'
@@ -87,7 +85,7 @@ alter table krsb_qrtz_triggers add column sched_name varchar(120) not null DEFAU
 /
 
 --
--- drop all primary and foreign key constraint s, so that we can define new ones
+-- drop all primary and foreign key constraints, so that we can define new ones
 --
  alter table krsb_qrtz_blob_triggers  drop foreign key KRSB_QRTZ_BLOB_TRIGGERS_TR1
 /
@@ -95,35 +93,35 @@ alter table krsb_qrtz_triggers add column sched_name varchar(120) not null DEFAU
 /
  alter table krsb_qrtz_cron_triggers drop foreign key KRSB_QRTZ_CRON_TRIGGERS_TR1
 /
- alter table krsb_qrtz_job_details drop primary key, add primary key (sched_name, job_name, job_group)
+ alter table krsb_qrtz_job_details drop primary key, add primary key (job_name, job_group, sched_name)
 /
 
 --
 -- add all primary and foreign key constraint s, based on new columns
 --
-alter table krsb_qrtz_triggers drop primary key, add primary key (sched_name, trigger_name, trigger_group)
+alter table krsb_qrtz_triggers drop primary key, add primary key (trigger_name, trigger_group, sched_name)
 /
-alter table krsb_qrtz_blob_triggers drop primary key, add primary key (sched_name, trigger_name, trigger_group)
+alter table krsb_qrtz_blob_triggers drop primary key, add primary key (trigger_name, trigger_group, sched_name)
 /
-alter table KRSB_QRTZ_BLOB_TRIGGERS add  constraint  KRSB_QRTZ_BLOB_TRIGGERS_TR1 foreign key(sched_name, trigger_name, trigger_group) references KRSB_QRTZ_TRIGGERS (sched_name, trigger_name, trigger_group)
+alter table KRSB_QRTZ_BLOB_TRIGGERS add  constraint  KRSB_QRTZ_BLOB_TRIGGERS_TR1 foreign key(trigger_name, trigger_group, sched_name) references KRSB_QRTZ_TRIGGERS (trigger_name, trigger_group, sched_name)
 /
-alter table krsb_qrtz_cron_triggers drop primary key, add primary key (sched_name, trigger_name, trigger_group)
+alter table krsb_qrtz_cron_triggers drop primary key, add primary key (trigger_name, trigger_group, sched_name)
 /
-alter table krsb_qrtz_cron_triggers add  constraint  KRSB_QRTZ_CRON_TRIGGERS_TR1 foreign key(sched_name, trigger_name, trigger_group) references krsb_qrtz_triggers(sched_name, trigger_name, trigger_group)
+alter table krsb_qrtz_cron_triggers add  constraint  KRSB_QRTZ_CRON_TRIGGERS_TR1 foreign key(trigger_name, trigger_group, sched_name) references krsb_qrtz_triggers(trigger_name, trigger_group, sched_name)
 /
-alter table krsb_qrtz_simple_triggers drop primary key, add primary key (sched_name, trigger_name, trigger_group)
+alter table krsb_qrtz_simple_triggers drop primary key, add primary key (trigger_name, trigger_group, sched_name)
 /
-alter table krsb_qrtz_simple_triggers add  constraint  KRSB_QRTZ_SIMPLE_TRIGGERS_TR1 foreign key(sched_name, trigger_name, trigger_group) references krsb_qrtz_triggers(sched_name, trigger_name, trigger_group)
+alter table krsb_qrtz_simple_triggers add  constraint  KRSB_QRTZ_SIMPLE_TRIGGERS_TR1 foreign key(trigger_name, trigger_group, sched_name) references krsb_qrtz_triggers(trigger_name, trigger_group, sched_name)
 /
-alter table krsb_qrtz_fired_triggers drop primary key, add primary key (sched_name, entry_id)
+alter table krsb_qrtz_fired_triggers drop primary key, add primary key (entry_id, sched_name)
 /
-alter table krsb_qrtz_calendars drop primary key, add primary key (sched_name, calendar_name)
+alter table krsb_qrtz_calendars drop primary key, add primary key (calendar_name, sched_name)
 /
-alter table krsb_qrtz_locks drop primary key, add primary key (sched_name, lock_name)
+alter table krsb_qrtz_locks drop primary key, add primary key (lock_name, sched_name)
 /
-alter table krsb_qrtz_paused_trigger_grps drop primary key, add primary key (sched_name, trigger_group)
+alter table krsb_qrtz_paused_trigger_grps drop primary key, add primary key (trigger_group, sched_name)
 /
-alter table krsb_qrtz_scheduler_state drop primary key, add primary key (sched_name, instance_name)
+alter table krsb_qrtz_scheduler_state drop primary key, add primary key (instance_name, sched_name)
 /
 --
 -- add new simprop_triggers table
@@ -146,7 +144,7 @@ CREATE TABLE krsb_qrtz_simprop_triggers
     BOOL_PROP_2 BOOL NULL,
     primary key (SCHED_NAME,TRIGGER_NAME,TRIGGER_GROUP),
     constraint KRSB_QRTZ_SIMPROP_TRIGGERS_TR1 foreign key(SCHED_NAME,TRIGGER_NAME,TRIGGER_GROUP)
-    references krsb_QRTZ_TRIGGERS(SCHED_NAME,TRIGGER_NAME,TRIGGER_GROUP)
+    references krsb_QRTZ_TRIGGERS(TRIGGER_NAME,TRIGGER_GROUP,SCHED_NAME)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
 /
  

--- a/db/sql/src/main/resources/org/kuali/rice/rice-sql/upgrades/2.6.0/oracle/server/bootstrap/2015-03-10--KULRICE-14144.sql
+++ b/db/sql/src/main/resources/org/kuali/rice/rice-sql/upgrades/2.6.0/oracle/server/bootstrap/2015-03-10--KULRICE-14144.sql
@@ -55,8 +55,6 @@ alter table krsb_qrtz_cron_triggers add sched_name varchar(120) DEFAULT 'KrTestS
 /
 alter table krsb_qrtz_fired_triggers add sched_name varchar(120)  DEFAULT 'KrTestScheduler' not null
 /
-alter table krsb_qrtz_fired_triggers add sched_time number(13) NOT NULL
-/
 alter table krsb_qrtz_job_details add sched_name varchar(120)  DEFAULT 'KrTestScheduler' not null
 /
 alter table krsb_qrtz_locks add sched_name varchar(120) DEFAULT 'KrTestScheduler' not null
@@ -92,43 +90,43 @@ alter table krsb_qrtz_triggers drop constraint KRSB_QRTZ_TRIGGERSP1
 --
 -- add all primary and foreign key constraints, based on new columns
 --
-alter table krsb_qrtz_job_details add constraint KRSB_QRTZ_JOB_DETAILSP1 primary key (sched_name, job_name, job_group)
+alter table krsb_qrtz_job_details add constraint KRSB_QRTZ_JOB_DETAILSP1 primary key (job_name, job_group, sched_name)
 /
-alter table krsb_qrtz_triggers add constraint KRSB_QRTZ_TRIGGERSP1 primary key (sched_name, trigger_name, trigger_group)
+alter table krsb_qrtz_triggers add constraint KRSB_QRTZ_TRIGGERSP1 primary key (trigger_name, trigger_group, sched_name)
 /
-alter table krsb_qrtz_triggers add constraint KRSB_QRTZ_TRIGGERS_TR1 foreign key (sched_name, job_name, job_group) references krsb_qrtz_job_details(sched_name, job_name, job_group)
+alter table krsb_qrtz_triggers add constraint KRSB_QRTZ_TRIGGERS_TR1 foreign key (job_name, job_group, sched_name) references krsb_qrtz_job_details(job_name, job_group, sched_name)
 /
-alter table krsb_qrtz_blob_triggers add constraint KRSB_QRTZ_BLOB_TRIGGERSP1 primary key (sched_name, trigger_name, trigger_group)
+alter table krsb_qrtz_blob_triggers add constraint KRSB_QRTZ_BLOB_TRIGGERSP1 primary key (trigger_name, trigger_group, sched_name)
 /
-alter table krsb_qrtz_blob_triggers add constraint KRSB_QRTZ_BLOB_TRIGGERS_TR1 foreign key (sched_name, trigger_name, trigger_group) references krsb_qrtz_triggers(sched_name, trigger_name, trigger_group)
+alter table krsb_qrtz_blob_triggers add constraint KRSB_QRTZ_BLOB_TRIGGERS_TR1 foreign key (trigger_name, trigger_group, sched_name) references krsb_qrtz_triggers(trigger_name, trigger_group, sched_name)
 /
-alter table krsb_qrtz_cron_triggers add constraint KRSB_QRTZ_CRON_TRIGGERSP1 primary key (sched_name, trigger_name, trigger_group)
+alter table krsb_qrtz_cron_triggers add constraint KRSB_QRTZ_CRON_TRIGGERSP1 primary key (trigger_name, trigger_group, sched_name)
 /
-alter table krsb_qrtz_cron_triggers add constraint KRSB_QRTZ_CRON_TRIGGERS_TR1 foreign key (sched_name, trigger_name, trigger_group) references krsb_qrtz_triggers(sched_name, trigger_name, trigger_group)
+alter table krsb_qrtz_cron_triggers add constraint KRSB_QRTZ_CRON_TRIGGERS_TR1 foreign key (trigger_name, trigger_group, sched_name) references krsb_qrtz_triggers(trigger_name, trigger_group, sched_name)
 /
-alter table krsb_qrtz_simple_triggers add constraint KRSB_QRTZ_SIMPLE_TRIGGERSP1 primary key (sched_name, trigger_name, trigger_group)
+alter table krsb_qrtz_simple_triggers add constraint KRSB_QRTZ_SIMPLE_TRIGGERSP1 primary key (trigger_name, trigger_group, sched_name)
 /
-alter table krsb_qrtz_simple_triggers add constraint KRSB_QRTZ_SIMPLE_TRIGGERS_TR1 foreign key (sched_name, trigger_name, trigger_group) references krsb_qrtz_triggers(sched_name, trigger_name, trigger_group)
+alter table krsb_qrtz_simple_triggers add constraint KRSB_QRTZ_SIMPLE_TRIGGERS_TR1 foreign key (trigger_name, trigger_group, sched_name) references krsb_qrtz_triggers(trigger_name, trigger_group, sched_name)
 /
 alter table krsb_qrtz_fired_triggers drop constraint KRSB_QRTZ_FIRED_TRIGGERSP1
 /
-alter table krsb_qrtz_fired_triggers add constraint KRSB_QRTZ_FIRED_TRIGGERSP1 primary key (sched_name, entry_id)
+alter table krsb_qrtz_fired_triggers add constraint KRSB_QRTZ_FIRED_TRIGGERSP1 primary key (entry_id, sched_name)
 /
 alter table krsb_qrtz_calendars drop constraint KRSB_QRTZ_CALENDARSP1
 /
-alter table krsb_qrtz_calendars add constraint KRSB_QRTZ_CALENDARSP1 primary key (sched_name, calendar_name)
+alter table krsb_qrtz_calendars add constraint KRSB_QRTZ_CALENDARSP1 primary key (calendar_name, sched_name)
 /
 alter table krsb_qrtz_locks drop constraint KRSB_QRTZ_LOCKSP1
 /
-alter table krsb_qrtz_locks add constraint KRSB_QRTZ_LOCKSP1 primary key (sched_name, lock_name)
+alter table krsb_qrtz_locks add constraint KRSB_QRTZ_LOCKSP1 primary key (lock_name, sched_name)
 /
 alter table krsb_qrtz_paused_trigger_grps drop constraint KRSB_QRTZ_PAUSED_TRIGGER_GRP1
 /
-alter table krsb_qrtz_paused_trigger_grps add constraint KRSB_QRTZ_PAUSED_TRIGGER_GRP1 primary key (sched_name, trigger_group)
+alter table krsb_qrtz_paused_trigger_grps add constraint KRSB_QRTZ_PAUSED_TRIGGER_GRP1 primary key (trigger_group, sched_name)
 /
 alter table krsb_qrtz_scheduler_state drop constraint KRSB_QRTZ_SCHEDULER_STATEP1
 /
-alter table krsb_qrtz_scheduler_state add constraint KRSB_QRTZ_SCHEDULER_STATEP1 primary key (sched_name, instance_name)
+alter table krsb_qrtz_scheduler_state add constraint KRSB_QRTZ_SCHEDULER_STATEP1 primary key (instance_name, sched_name)
 /
 --
 -- add new simprop_triggers table
@@ -151,6 +149,6 @@ CREATE TABLE krsb_qrtz_simprop_triggers
     BOOL_PROP_2 VARCHAR2(1) NULL,
     constraint KRSB_QRTZ_SIMPROP_TRIGGERSP1 primary key (SCHED_NAME,TRIGGER_NAME,TRIGGER_GROUP),
     constraint KRSB_QRTZ_SIMPROP_TRIGGERS_TR1 foreign key (SCHED_NAME,TRIGGER_NAME,TRIGGER_GROUP) 
-    references KRSB_QRTZ_TRIGGERS(SCHED_NAME,TRIGGER_NAME,TRIGGER_GROUP)
+    references KRSB_QRTZ_TRIGGERS(TRIGGER_NAME,TRIGGER_GROUP, SCHED_NAME)
 )
 /


### PR DESCRIPTION
* Impex doesn't support ordering of the primary keys.  They are always in the same order as they appear in the table. Order of the constrains columns need to match the primary key order (for mysql). These changes makes sure that the order matches. 
* The SCHED_TIME column isn't used and not part of the quartz update (see http://quartz-scheduler.org/documentation/quartz-2.x/migration-guide )