### PR TITLE
Not Ready until after 2.3 release -- KULRICE-14255 - Fix for PersonServiceImplTest AND RoleRouteModuleTest

### DIFF
--- a/rice-middleware/it/kew/src/test/java/org/kuali/rice/kew/role/RoleRouteModuleTest.java
+++ b/rice-middleware/it/kew/src/test/java/org/kuali/rice/kew/role/RoleRouteModuleTest.java
@@ -159,7 +159,7 @@ public class RoleRouteModuleTest extends KEWTestCase {
         role.setActive(true);
         role.setKimTypeId(kimType.getId());
 
-        String roleMemberId1 = "" + KRADServiceLocator.getSequenceAccessorService().getNextAvailableSequenceNumber("KRIM_ROLE_ID_S");
+        String roleMemberId1 = "" + KRADServiceLocator.getSequenceAccessorService().getNextAvailableSequenceNumber("KRIM_ROLE_MBR_ID_S");
         RoleMemberBo adminRolePrincipal = new RoleMemberBo();
         adminRolePrincipal.setId(roleMemberId1);
         adminRolePrincipal.setRoleId(roleId);
@@ -168,7 +168,7 @@ public class RoleRouteModuleTest extends KEWTestCase {
         adminRolePrincipal.setMemberId(adminPrincipal.getPrincipalId());
         adminRolePrincipal.setType( MemberType.PRINCIPAL );
 
-        String roleMemberId2 = "" + KRADServiceLocator.getSequenceAccessorService().getNextAvailableSequenceNumber("KRIM_ROLE_ID_S");
+        String roleMemberId2 = "" + KRADServiceLocator.getSequenceAccessorService().getNextAvailableSequenceNumber("KRIM_ROLE_MBR_ID_S");
         RoleMemberBo user2RolePrincipal = new RoleMemberBo();
         user2RolePrincipal.setId(roleMemberId2);
         user2RolePrincipal.setRoleId(roleId);
@@ -177,7 +177,7 @@ public class RoleRouteModuleTest extends KEWTestCase {
         user2RolePrincipal.setMemberId(user2Principal.getPrincipalId());
         user2RolePrincipal.setType( MemberType.PRINCIPAL );
 
-        String roleMemberId3 = "" + KRADServiceLocator.getSequenceAccessorService().getNextAvailableSequenceNumber("KRIM_ROLE_ID_S");
+        String roleMemberId3 = "" + KRADServiceLocator.getSequenceAccessorService().getNextAvailableSequenceNumber("KRIM_ROLE_MBR_ID_S");
         RoleMemberBo user1RolePrincipal = new RoleMemberBo();
         user1RolePrincipal.setId(roleMemberId3);
         user1RolePrincipal.setRoleId(roleId);

--- a/rice-middleware/it/kim/src/test/java/org/kuali/rice/kim/test/service/UiDocumentServiceImplTest.java
+++ b/rice-middleware/it/kim/src/test/java/org/kuali/rice/kim/test/service/UiDocumentServiceImplTest.java
@@ -236,7 +236,7 @@ public class UiDocumentServiceImplTest extends KIMTestCase {
 		personDoc.setEntityId("ent123");
 		personDoc.setDocumentNumber("1");
 		personDoc.setPrincipalId("pid123");
-		personDoc.setPrincipalName("test");
+		personDoc.setPrincipalName("quickTest");
 //		personDoc.setUnivId("1234567890");
 		personDoc.setAffiliations(initAffiliations());
 		personDoc.setNames(initNames());


### PR DESCRIPTION
 For PersonServiceImplTest,  I changed a line in UiDocumentServiceImplTest since it was causing PersonServiceImplTest.testFindPeopleByWildcard to fail if iDocumentServiceImplTest.testSaveToEntity ran before it in CI.

For RoleRouteModuleTest, the wrong sequence was being used to create role members.  (KRIM_ROLE_ID_S instead of KRIM_ROLE_MBR_ID_S).   I was able to recreate the error if I adjusted the KRIM_ROLE_ID_S to interfere with the already existing items on the KRIM_ROLE_MBR_T.