### PR TITLE
KULRICE-14258 & KULRICE-14256 - Failing AFTs in 2.6

### DIFF
--- a/rice-middleware/sampleapp/src/it/java/edu/sampleu/admin/CampusAftBase.java
+++ b/rice-middleware/sampleapp/src/it/java/edu/sampleu/admin/CampusAftBase.java
@@ -27,6 +27,7 @@ public abstract class CampusAftBase extends AdminTmplMthdAftNavCreateNewBase {
         String randomAlphabetic = RandomStringUtils.randomAlphabetic(10);
         String randomNumbeForCode = RandomStringUtils.randomNumeric(1);
         String randomAlphabeticForCode = RandomStringUtils.randomAlphabetic(1);
+        clearTextByName("document.newMaintainableObject.code");
         waitAndTypeByName("document.newMaintainableObject.code",randomNumbeForCode + randomAlphabeticForCode);
         waitAndTypeByName("document.newMaintainableObject.name",randomAlphabetic);
         waitAndTypeByName("document.newMaintainableObject.shortName",randomAlphabetic);

--- a/rice-middleware/sampleapp/src/it/java/edu/sampleu/main/AgendaEditorAndOrToggleSyncAft.java
+++ b/rice-middleware/sampleapp/src/it/java/edu/sampleu/main/AgendaEditorAndOrToggleSyncAft.java
@@ -264,7 +264,7 @@ public class AgendaEditorAndOrToggleSyncAft extends WebDriverLegacyITBase {
         waitAndClickByXpath("//a[@class='agendaNode ruleNode']");
         waitAndClickByXpath("//button[contains(text(),'Edit Rule')]");
         selectFrameIframePortlet();
-        selectByName("document.newMaintainableObject.dataObject.agendaItemLineRuleAction.typeId", selectValue);
+        waitAndSelectByName("document.newMaintainableObject.dataObject.agendaItemLineRuleAction.typeId", selectValue);
 
         if (selectValue.equals("KrmsActionResolverType") || selectValue.equalsIgnoreCase("Validation Action")){
             waitClearAndType("document.newMaintainableObject.dataObject.agendaItemLineRuleAction.name", "ActionName");
@@ -285,6 +285,7 @@ public class AgendaEditorAndOrToggleSyncAft extends WebDriverLegacyITBase {
     }
 
     protected void waitClearAndType(String name, String value) throws Exception {
+        waitForElementPresent(name);
         clearTextByName(name);
         waitAndTypeByName(name,value);
     }

--- a/rice-tools-test/src/main/java/org/kuali/rice/testtools/selenium/WebDriverLegacyITBase.java
+++ b/rice-tools-test/src/main/java/org/kuali/rice/testtools/selenium/WebDriverLegacyITBase.java
@@ -1087,8 +1087,7 @@ public abstract class WebDriverLegacyITBase extends WebDriverAftBase {
         waitAndClickBlanketApproveKns();
 
         int attempts = 0;
-        while (hasDocError() && extractErrorText().contains("a record with the same primary key already exists.") &&
-                ++attempts <= 10) {
+        while (isTextPresent("a record with the same primary key already exists.") && ++attempts <= 10) {
             uniqueString = null; // make sure try a new one
             jGrowl("record with the same primary key already exists");
             createNewEnterDetails();
@@ -1182,8 +1181,7 @@ public abstract class WebDriverLegacyITBase extends WebDriverAftBase {
         waitAndClickSave();
 
         int attempts = 0;
-        while (hasDocError() && extractErrorText().contains("a record with the same primary key already exists.") &&
-                ++attempts <= 10) {
+        while (isTextPresent("a record with the same primary key already exists.") && ++attempts <= 10) {
             uniqueString = null; // make sure try a new one
             jGrowl("record with the same primary key already exists");
             createNewEnterDetails();
@@ -1210,8 +1208,7 @@ public abstract class WebDriverLegacyITBase extends WebDriverAftBase {
         createNewEnterDetails();
         waitAndClickSubmit();
         int attempts = 0;
-        while (hasDocError() && extractErrorText().contains("a record with the same primary key already exists.") &&
-                ++attempts <= 10) {
+        while (isTextPresent("a record with the same primary key already exists.") && ++attempts <= 10) {
             uniqueString = null; // make sure try a new one
             jGrowl("record with the same primary key already exists");
             createNewEnterDetails();
@@ -1238,8 +1235,7 @@ public abstract class WebDriverLegacyITBase extends WebDriverAftBase {
         waitAndClickSave();
 
         int attempts = 0;
-        while (hasDocError() && extractErrorText().contains("a record with the same primary key already exists.") &&
-                ++attempts <= 10) {
+        while (isTextPresent("a record with the same primary key already exists.") && ++attempts <= 10) {
             uniqueString = null; // make sure try a new one
             jGrowl("record with the same primary key already exists");
             createNewEnterDetails();


### PR DESCRIPTION
The document.newMaintainableObject.code was not getting cleared if it was a duplicate so even though the test appeared to be getting a new code, it was not actually replacing the code on the screen.  

Also include minor fix for AgendaEditorAndOrToggleSyncAft.