### PR TITLE
Update javadocs for ImmutableProperties to document Properties defaults not being added

### DIFF
--- a/rice-middleware/core/impl/src/main/java/org/kuali/rice/core/util/ImmutableProperties.java
+++ b/rice-middleware/core/impl/src/main/java/org/kuali/rice/core/util/ImmutableProperties.java
@@ -24,7 +24,12 @@ import java.util.Map;
 import java.util.Properties;
 
 /**
- * This is a description of what this class does - g don't forget to fill this in. 
+ * This is a wrapper for the Properties class that prevents other objects from making
+ * changes to the properties stored within it by throwing a UnsupportedOperationException.
+ *
+ * Any default Properties in the Properties passed into ImmutableProperties(Properties)} will
+ * not be added to the ImmutableProperties as keySet is used to copy properties rather than
+ * propertyNames.
  * 
  * @author Kuali Rice Team (rice.collab@kuali.org)
  *


### PR DESCRIPTION
While working on updating rice 1.0.3.2 to JDK8 I noticed the ImmutableProperties behavior of not adding Properties defaults and updated the javadoc to document said behavior.