### PR TITLE
Rice 2.5 rice 2 optimistic lock role delegation

### DIFF
--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kim/bo/ui/RoleDocumentDelegation.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kim/bo/ui/RoleDocumentDelegation.java
@@ -15,7 +15,11 @@
  */
 package org.kuali.rice.kim.bo.ui;
 
-import java.util.List;
+import org.eclipse.persistence.annotations.JoinFetch;
+import org.eclipse.persistence.annotations.JoinFetchType;
+import org.kuali.rice.core.api.delegation.DelegationType;
+import org.kuali.rice.krad.data.jpa.PortableSequenceGenerator;
+import org.springframework.util.AutoPopulatingList;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -27,12 +31,7 @@ import javax.persistence.JoinColumns;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.Transient;
-
-import org.eclipse.persistence.annotations.JoinFetch;
-import org.eclipse.persistence.annotations.JoinFetchType;
-import org.kuali.rice.core.api.delegation.DelegationType;
-import org.kuali.rice.krad.data.jpa.PortableSequenceGenerator;
-import org.springframework.util.AutoPopulatingList;
+import java.util.List;
 
 /**
  * This is a description of what this class does - kellerj don't forget to fill this in.
@@ -62,7 +61,7 @@ public class RoleDocumentDelegation extends KimDocumentBoActivatableBase {
     protected String delegationTypeCode;
 
     @JoinFetch(value= JoinFetchType.OUTER)
-    @OneToMany(targetEntity = RoleDocumentDelegationMember.class, orphanRemoval = true, cascade = { CascadeType.REFRESH, CascadeType.REMOVE, CascadeType.PERSIST })
+    @OneToMany(targetEntity = RoleDocumentDelegationMember.class, orphanRemoval = true, cascade = CascadeType.ALL)
     @JoinColumns({ 
         @JoinColumn(name = "FDOC_NBR", referencedColumnName = "FDOC_NBR", insertable = false, updatable = false), 
         @JoinColumn(name = "DLGN_ID", referencedColumnName = "DLGN_ID", insertable = false, updatable = false) })

--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kim/document/IdentityManagementKimDocument.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kim/document/IdentityManagementKimDocument.java
@@ -61,6 +61,9 @@ public class IdentityManagementKimDocument extends TransactionalDocumentBase {
 	protected List<RoleDocumentDelegationMember> delegationMembers = new AutoPopulatingList<RoleDocumentDelegationMember>(RoleDocumentDelegationMember.class);
 	
 	protected void addDelegationMemberToDelegation(RoleDocumentDelegationMember delegationMember){
+		// the statement below will lazily load the RoleBo onto our delegation member so that we have access to i
+		delegationMember.loadTransientRoleFields();
+		// now that we've done that we can fetch the RoleBo
 		RoleBo role = delegationMember.getRoleBo();
 		RoleDocumentDelegation delegation;
 		if (DelegationType.PRIMARY.getCode().equals(delegationMember.getDelegationTypeCode())) {
@@ -83,6 +86,7 @@ public class IdentityManagementKimDocument extends TransactionalDocumentBase {
 		for(RoleDocumentDelegation delegation: getDelegations()){
 			if(role.getId().equals(delegation.getRoleId()) && delegation.isDelegationPrimary()) {
 				primaryDelegation = delegation;
+				break;
             }
 		}
 		if(primaryDelegation == null) {
@@ -107,6 +111,7 @@ public class IdentityManagementKimDocument extends TransactionalDocumentBase {
 		for (RoleDocumentDelegation delegation: getDelegations()) {
 			if (role.getId().equals(delegation.getRoleId()) && delegation.isDelegationSecondary()) {
 				secondaryDelegation = delegation;
+				break;
             }
 		}
 		if(secondaryDelegation == null) {

--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kim/service/impl/UiDocumentServiceImpl.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kim/service/impl/UiDocumentServiceImpl.java
@@ -441,28 +441,31 @@ public class UiDocumentServiceImpl implements UiDocumentService {
 		RoleMemberBo roleMember;
 		if(ObjectUtils.isNotNull(members)){
 			for(DelegateMemberBo member: members){
-				pndMember = new RoleDocumentDelegationMember();
-				pndMember.setActiveFromDate(member.getActiveFromDateValue());
-				pndMember.setActiveToDate(member.getActiveToDateValue());
-				pndMember.setActive(member.isActive( getDateTimeService().getCurrentTimestamp() ));
-				pndMember.setRoleBo( RoleBo.from(roleImpl) );
-				if(pndMember.isActive()){
-                    pndMember.setMemberId(member.getMemberId());
-                    pndMember.setDelegationMemberId(member.getDelegationMemberId());
-                    pndMember.setMemberTypeCode(member.getType().getCode());
-                    pndMember.setDelegationId(member.getDelegationId());
+				// only include delegation members that match the person
+				if (MemberType.PRINCIPAL.equals(member.getType()) && member.getMemberId().equals(identityManagementPersonDocument.getPrincipalId())) {
+					pndMember = new RoleDocumentDelegationMember();
+					pndMember.setActiveFromDate(member.getActiveFromDateValue());
+					pndMember.setActiveToDate(member.getActiveToDateValue());
+					pndMember.setActive(member.isActive(getDateTimeService().getCurrentTimestamp()));
+					pndMember.setRoleBo(RoleBo.from(roleImpl));
+					if (pndMember.isActive()) {
+						pndMember.setMemberId(member.getMemberId());
+						pndMember.setDelegationMemberId(member.getDelegationMemberId());
+						pndMember.setMemberTypeCode(member.getType().getCode());
+						pndMember.setDelegationId(member.getDelegationId());
 
-					pndMember.setRoleMemberId(member.getRoleMemberId());
-					roleMember = getRoleMemberForRoleMemberId(member.getRoleMemberId());
-					if(roleMember!=null){
-						pndMember.setRoleMemberName(getMemberName(roleMember.getType(), roleMember.getMemberId()));
-						pndMember.setRoleMemberNamespaceCode(getMemberNamespaceCode(roleMember.getType(), roleMember.getMemberId()));
+						pndMember.setRoleMemberId(member.getRoleMemberId());
+						roleMember = getRoleMemberForRoleMemberId(member.getRoleMemberId());
+						if (roleMember != null) {
+							pndMember.setRoleMemberName(getMemberName(roleMember.getType(), roleMember.getMemberId()));
+							pndMember.setRoleMemberNamespaceCode(getMemberNamespaceCode(roleMember.getType(), roleMember.getMemberId()));
+						}
+						pndMember.setMemberNamespaceCode(getMemberNamespaceCode(member.getType(), member.getMemberId()));
+						pndMember.setMemberName(getMemberName(member.getType(), member.getMemberId()));
+						pndMember.setEdit(true);
+						pndMember.setQualifiers(loadDelegationMemberQualifiers(identityManagementPersonDocument, pndMember.getAttributesHelper().getDefinitions(), member.getAttributeDetails()));
+						pndMembers.add(pndMember);
 					}
-					pndMember.setMemberNamespaceCode(getMemberNamespaceCode(member.getType(), member.getMemberId()));
-					pndMember.setMemberName(getMemberName(member.getType(), member.getMemberId()));
-					pndMember.setEdit(true);
-					pndMember.setQualifiers(loadDelegationMemberQualifiers(identityManagementPersonDocument, pndMember.getAttributesHelper().getDefinitions(), member.getAttributeDetails()));
-					pndMembers.add(pndMember);
 				}
 			}
 		}

--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kim/service/impl/UiDocumentServiceImpl.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kim/service/impl/UiDocumentServiceImpl.java
@@ -1581,6 +1581,7 @@ public class UiDocumentServiceImpl implements UiDocumentService {
 				for (DelegateMemberBo anOriginalMember : delegationMembers) {
 					if (StringUtils.equals(anOriginalMember.getDelegationMemberId(), documentDelegationMember.getDelegationMemberId())) {
 						newMember = originalMember = anOriginalMember;
+						break;
 					}
 				}
 				if (originalMember == null) {
@@ -1595,13 +1596,38 @@ public class UiDocumentServiceImpl implements UiDocumentService {
 				newMember.setTypeCode(documentDelegationMember.getMemberTypeCode());
 				newMember.setActiveFromDateValue(documentDelegationMember.getActiveFromDate());
 				newMember.setActiveToDateValue(documentDelegationMember.getActiveToDate());
-
-				// TODO still need to deal with attributes on delegate members...
-				// newMember.setAttributeDetails(..., originalMember, ...);
+				newMember.setAttributeDetails(populateDelegateMemberAttributes(newMember, documentDelegationMember));
 			}
 		}
 		return delegationMembers;
 
+	}
+
+	protected List<DelegateMemberAttributeDataBo> populateDelegateMemberAttributes(DelegateMemberBo member, RoleDocumentDelegationMember documentMember) {
+		List<DelegateMemberAttributeDataBo> originalAttributes = member.getAttributeDetails();
+		List<DelegateMemberAttributeDataBo> newAttributes = new ArrayList<>();
+		if (CollectionUtils.isNotEmpty(documentMember.getQualifiers())) {
+			for (RoleDocumentDelegationMemberQualifier qualifier : documentMember.getQualifiers()) {
+				DelegateMemberAttributeDataBo newAttribute = new DelegateMemberAttributeDataBo();
+				for (DelegateMemberAttributeDataBo originalAttribute : originalAttributes) {
+					// they will have the same id if they represent the same attribute
+					if (StringUtils.equals(originalAttribute.getId(), qualifier.getAttrDataId())) {
+						newAttribute = originalAttribute;
+						break;
+					}
+				}
+				// only save an attribute if it has an actual value
+				if (StringUtils.isNotBlank(qualifier.getAttrVal())) {
+					newAttribute.setId(qualifier.getAttrDataId());
+					newAttribute.setAttributeValue(qualifier.getAttrVal());
+					newAttribute.setAssignedToId(qualifier.getDelegationMemberId());
+					newAttribute.setKimTypeId(qualifier.getKimTypId());
+					newAttribute.setKimAttributeId(qualifier.getKimAttrDefnId());
+					newAttributes.add(newAttribute);
+				}
+			}
+		}
+		return newAttributes;
 	}
 
 	protected List <RoleMemberAttributeDataBo> getBlankRoleMemberAttrs(List <RoleMemberBo> rolePrncpls) {

--- a/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/KIMPropertyConstants.java
+++ b/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/KIMPropertyConstants.java
@@ -165,6 +165,7 @@ public final class KIMPropertyConstants {
 	public static final class Delegation {
 		public static final String ROLE_ID = "roleId";
 		public static final String DELEGATION_ID = "delegationId";
+		public static final String DELEGATION_TYPE_CODE = "delegationTypeCode";
 		public static final String ACTIVE = KRADPropertyConstants.ACTIVE;
 		
 		private Delegation() {

--- a/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/common/delegate/DelegateTypeBo.java
+++ b/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/common/delegate/DelegateTypeBo.java
@@ -63,9 +63,9 @@ public class DelegateTypeBo extends DataObjectBase implements DelegateTypeContra
     @Column(name = "DLGN_TYP_CD")
     private String delegationTypeCode;
 
-    @JoinFetch(value= JoinFetchType.OUTER)
+    @JoinFetch(value = JoinFetchType.OUTER)
     @OneToMany(targetEntity = DelegateMemberBo.class, orphanRemoval = true, cascade = CascadeType.ALL)
-    @JoinColumn(name = "DLGN_ID", referencedColumnName = "DLGN_ID", insertable = false, updatable = false)
+    @JoinColumn(name = "DLGN_ID", referencedColumnName = "DLGN_ID")
     private List<DelegateMemberBo> members = new AutoPopulatingList<DelegateMemberBo>(DelegateMemberBo.class);
 
     public void setDelegationType(DelegationType type) {

--- a/rice-middleware/web/src/main/webapp/WEB-INF/tags/kim/personDelegations.tag
+++ b/rice-middleware/web/src/main/webapp/WEB-INF/tags/kim/personDelegations.tag
@@ -104,7 +104,7 @@
 					<td>
 						<div align=center>&nbsp;
 			        	     <c:choose>
-				        	       <c:when test="${role.edit or readOnly}">
+				        	       <c:when test="${delegationMember.edit or readOnly}">
 				        	          <img class='nobord' src='${ConfigProperties.kr.externalizable.images.url}tinybutton-delete2.gif' styleClass='tinybutton'/>
 				        	       </c:when>
 				        	       <c:otherwise>


### PR DESCRIPTION
Made a number of fixes to how the person document handles delegations and delegation members (as well as some shared code between that document and the role document). It should be more resiliant and handle the following scenarios properly now:

* When someone changes the active to date it is no longer throwing an optimistic lock exception from JPA
* It's now possible to change the delegation type on a delegation member and have it migrated to the appropriate delegation (previously the data was ending up in a partially corrupted state)
* It's possible to save the person document and come back to the document later and still have the delegations preserved (previously they were not being displayed due in large part to the way that JPA does not preserve values for transient fields after a merge operation)
* Made is so that you can't actually "delete" delegation members, instead you need to set active to date to today's date (this is consistent with behavior elsewhere on the document)

In general, I actually ended up rewriting from scratch most of the code that handled delegations, delegation members, and delegation attributes as well as handling some code to ensure that the various transient values on a RoleDocumentDelegationMember were being re-established in various scenarios.