### PR TITLE
Rice 2.5 rice 2 delegation data fixes

### DIFF
--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kim/web/struts/action/DataIntegrityAction.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kim/web/struts/action/DataIntegrityAction.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2005-2015 The Kuali Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.opensource.org/licenses/ecl2.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.rice.kim.web.struts.action;
+
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.kuali.rice.core.api.util.RiceConstants;
+import org.kuali.rice.kim.api.role.RoleService;
+import org.kuali.rice.kim.api.services.KimApiServiceLocator;
+import org.kuali.rice.kim.impl.data.DataIntegrityService;
+import org.kuali.rice.kim.impl.services.KimImplServiceLocator;
+import org.kuali.rice.kns.web.struts.action.KualiAction;
+import org.kuali.rice.krad.exception.AuthorizationException;
+import org.kuali.rice.krad.util.GlobalVariables;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+public class DataIntegrityAction extends KualiAction {
+
+	/**
+	 * To avoid having to go through the pain of setting up a KIM permission for "Use Screen" for this utility screen,
+	 * we'll hardcode this screen to the "KR-SYS Technical Administrator" role. Without doing this, the screen is open
+	 * to all users until that permission is setup which could be considered a security issue.
+	 */
+	protected void checkAuthorization( ActionForm form, String methodToCall) throws AuthorizationException
+	{
+		boolean authorized = false;
+		String principalId = GlobalVariables.getUserSession().getPrincipalId();
+		RoleService roleService = KimApiServiceLocator.getRoleService();
+		String roleId = roleService.getRoleIdByNamespaceCodeAndName("KR-SYS", "Technical Administrator");
+		if (roleId != null) {
+			authorized = roleService.principalHasRole(principalId, Collections.singletonList(roleId),
+					new HashMap<String, String>(), true);
+		}
+
+		if (!authorized) {
+			throw new AuthorizationException(GlobalVariables.getUserSession().getPerson().getPrincipalName(),
+					methodToCall,
+					this.getClass().getSimpleName());
+		}
+	}
+
+	public ActionForward check(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+		List<String> messages = getDataIntegrityService().checkIntegrity();
+		if (messages.isEmpty()) {
+			messages = Collections.singletonList("No data integrity issues found.");
+		}
+		request.setAttribute("checkMessages", messages);
+		return mapping.findForward(RiceConstants.MAPPING_BASIC);
+	}
+
+	public ActionForward repair(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+		List<String> messages = getDataIntegrityService().repair();
+		if (messages.isEmpty()) {
+			messages = Collections.singletonList("No data repair was necessary.");
+		}
+		request.setAttribute("repairMessages", messages);
+		return mapping.findForward(RiceConstants.MAPPING_BASIC);
+	}
+
+	public DataIntegrityService getDataIntegrityService() {
+		return KimImplServiceLocator.getDataIntegrityService();
+	}
+
+}

--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kim/web/struts/form/DataIntegrityForm.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kim/web/struts/form/DataIntegrityForm.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2005-2015 The Kuali Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.opensource.org/licenses/ecl2.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.rice.kim.web.struts.form;
+
+import org.kuali.rice.kns.web.struts.form.KualiForm;
+
+public class DataIntegrityForm extends KualiForm {}

--- a/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/data/DataIntegrityService.java
+++ b/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/data/DataIntegrityService.java
@@ -1,0 +1,11 @@
+package org.kuali.rice.kim.impl.data;
+
+import java.util.List;
+
+public interface DataIntegrityService {
+
+    List<String> checkIntegrity();
+
+    List<String> repair();
+
+}

--- a/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/data/DataIntegrityService.java
+++ b/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/data/DataIntegrityService.java
@@ -2,10 +2,26 @@ package org.kuali.rice.kim.impl.data;
 
 import java.util.List;
 
+/**
+ * A simple service for checking integrity of KIM data and for performing automatic repair of the data if issues are
+ * found.
+ *
+ * @author Eric Westfall
+ */
 public interface DataIntegrityService {
 
+    /**
+     * Performs and integrity check on KIM data, returning a list of messages.
+     *
+     * @return a list of messages detailing the results of the integrity check
+     */
     List<String> checkIntegrity();
 
+    /**
+     * Executes any automatic repair of data integrity issues on KIM data, returning a list of messages.
+     *
+     * @return a list of messages detailing the results of the data repair
+     */
     List<String> repair();
 
 }

--- a/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/data/DataIntegrityServiceImpl.java
+++ b/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/data/DataIntegrityServiceImpl.java
@@ -1,0 +1,264 @@
+package org.kuali.rice.kim.impl.data;
+
+import org.kuali.rice.krad.data.platform.MaxValueIncrementerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.support.incrementer.DataFieldMaxValueIncrementer;
+
+import javax.sql.DataSource;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class DataIntegrityServiceImpl implements DataIntegrityService, InitializingBean {
+
+    private static final String DUPLICATE_DELEGATIONS = "select role_id, dlgn_typ_cd, kim_typ_id, count(*) cnt from krim_dlgn_t where actv_ind = 'Y' group by role_id, dlgn_typ_cd, kim_typ_id having cnt > 1";
+    private static final String BAD_DELEGATION_MEMBERS = "select m.dlgn_mbr_id, m.role_mbr_id, rm.role_id, r.kim_typ_id, d.dlgn_id, d.role_id, d.dlgn_typ_cd from krim_dlgn_t d, krim_dlgn_mbr_t m, krim_role_mbr_t rm, krim_role_t r where d.actv_ind = 'Y' and d.dlgn_id=m.dlgn_id and m.role_mbr_id=rm.role_mbr_id and rm.role_id=r.role_id and d.role_id != rm.role_id";
+
+    private static final String DUPLICATE_DELEGATION_IDS = "select dlgn_id from krim_dlgn_t where role_id = ? and dlgn_typ_cd = ? and kim_typ_id = ? and actv_ind = 'Y'";
+    private static final String FIX_DUPLICATE_DELEGATION_ID = "update krim_dlgn_mbr_t set dlgn_id = ? where dlgn_id = ?";
+    private static final String DELETE_DUPLICATE_DELEGATION = "delete from krim_dlgn_t where dlgn_id = ?";
+
+    private static final String FIND_TARGET_DELEGATION = "select dlgn_id from krim_dlgn_t where role_id = ? and dlgn_typ_cd = ? and actv_ind = 'Y'";
+    private static final String CREATE_DELEGATION = "insert into krim_dlgn_t (dlgn_id, obj_id, role_id, kim_typ_id, dlgn_typ_cd, ver_nbr, actv_ind) values (?, ?, ?, ?, ?, 1, 'Y')";
+    private static final String FIX_BAD_DELEGATION_MEMBER = "update krim_dlgn_mbr_t set dlgn_id = ? where dlgn_mbr_id = ?";
+
+    private DataSource dataSource;
+    private JdbcTemplate template;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        this.template = new JdbcTemplate(dataSource);
+    }
+
+    @Override
+    public List<String> checkIntegrity() {
+        List<String> messages = new ArrayList<>();
+        messages.addAll(reportDuplicateDelegations(findDuplicateDelegations()));
+        messages.addAll(reportBadDelegationMembers(findBadDelegationMembers()));
+        return messages;
+    }
+
+    private List<String> reportDuplicateDelegations(List<DuplicateRoleDelegation> duplicateRoleDelegations) {
+        List<String> reports = new ArrayList<>();
+        for (DuplicateRoleDelegation duplicateRoleDelegation : duplicateRoleDelegations) {
+            reports.add(duplicateRoleDelegation.report());
+        }
+        return reports;
+    }
+
+    private List<String> reportBadDelegationMembers(List<BadDelegationMember> badDelegationMembers) {
+        List<String> reports = new ArrayList<>();
+        for (BadDelegationMember badDelegationMember : badDelegationMembers) {
+            reports.add(badDelegationMember.report());
+        }
+        return reports;
+    }
+
+    @Override
+    public List<String> repair() {
+        List<String> messages = new ArrayList<>();
+        messages.addAll(repairDuplicateDelegations());
+        messages.addAll(repairBadDelegationMembers());
+        return messages;
+    }
+
+    private List<String> repairDuplicateDelegations() {
+        List<String> messages = new ArrayList<>();
+        List<DuplicateRoleDelegation> duplicateRoleDelegations = findDuplicateDelegations();
+        for (DuplicateRoleDelegation duplicateRoleDelegation : duplicateRoleDelegations) {
+            messages.add(repairDuplicateDelegation(duplicateRoleDelegation));
+        }
+        return messages;
+    }
+
+    private String repairDuplicateDelegation(DuplicateRoleDelegation duplicateRoleDelegation) {
+
+        // first let's find all of the duplicate delegation ids
+        List<String> delegationIds = template.query(DUPLICATE_DELEGATION_IDS,
+                new RowMapper<String>() {
+                    @Override
+                    public String mapRow(ResultSet resultSet, int i) throws SQLException {
+                        return resultSet.getString(1);
+                    }
+                },
+                duplicateRoleDelegation.roleId,
+                duplicateRoleDelegation.delegationTypeCode,
+                duplicateRoleDelegation.kimTypeId);
+        // we'll keep the first delegation and repoint all members to it instead, then delete the remaining
+        // duplicate delegations
+        String delegationIdToKeep = delegationIds.remove(0);
+
+        for (String delegationId : delegationIds) {
+            template.update(FIX_DUPLICATE_DELEGATION_ID, delegationIdToKeep, delegationId);
+            template.update(DELETE_DUPLICATE_DELEGATION, delegationId);
+        }
+
+        return reportRepairDuplicateDelegation(duplicateRoleDelegation, delegationIdToKeep, delegationIds);
+    }
+
+    private String reportRepairDuplicateDelegation(DuplicateRoleDelegation duplicateRoleDelegation,
+                                                   String delegationIdToKeep, List<String> duplicateDelegationIds) {
+        StringBuilder message = new StringBuilder();
+        message.append("Repaired duplicate delegations with roleId = ").append(duplicateRoleDelegation.roleId)
+                .append(", delegationTypeCode = ").append(duplicateRoleDelegation.delegationTypeCode)
+                .append(", and kimTypeId = ").append(duplicateRoleDelegation.kimTypeId)
+                .append(". Retained delegation with id ").append(delegationIdToKeep)
+                .append(". Deleted the following delegations and repointed their members to delegation id ")
+                .append(delegationIdToKeep).append(": [ ");
+        for (String duplicateDelegationId : duplicateDelegationIds) {
+            message.append(duplicateDelegationId).append(", ");
+        }
+        message.delete(message.length() - 2, message.length());
+        message.append(" ]");
+        return message.toString();
+    }
+
+    private List<String> repairBadDelegationMembers() {
+        List<String> messages = new ArrayList<>();
+        List<BadDelegationMember> badDelegationMembers = findBadDelegationMembers();
+        for (BadDelegationMember badDelegationMember : badDelegationMembers) {
+            messages.add(repairBadDelegationMember(badDelegationMember));
+        }
+        return messages;
+    }
+
+    private String repairBadDelegationMember(BadDelegationMember badDelegationMember) {
+        // first attempt to find an existing delegation for the proper role id + delegation type code
+        List<String> delegationIds = template.query(FIND_TARGET_DELEGATION,
+                new RowMapper<String>() {
+                    @Override
+                    public String mapRow(ResultSet resultSet, int i) throws SQLException {
+                        return resultSet.getString(1);
+                    }
+                },
+                badDelegationMember.roleMemberRoleId,
+                badDelegationMember.delegationTypeCode);
+
+        // if delegationIds is empty, then we will need to manufacture a delegation, otherwise there should only be one
+        // target delegation id since we just previously ran the repair to get rid of duplicate delegations
+        String targetDelegationId;
+        boolean newDelegationCreated = false;
+        if (delegationIds.isEmpty()) {
+            targetDelegationId = getNextDelegationId();
+            String objectId = UUID.randomUUID().toString();
+            template.update(CREATE_DELEGATION, targetDelegationId, objectId, badDelegationMember.roleMemberRoleId,
+                    badDelegationMember.roleMemberRoleKimTypeId, badDelegationMember.delegationTypeCode);
+            newDelegationCreated = true;
+        } else {
+            targetDelegationId = delegationIds.get(0);
+        }
+        // now that we have the target delegation id, let's update our delegation member and point it to the proper delegation
+        template.update(FIX_BAD_DELEGATION_MEMBER, targetDelegationId, badDelegationMember.delegationMemberId);
+        return reportRepairBadDelegationMember(badDelegationMember, targetDelegationId, newDelegationCreated);
+    }
+
+    private String reportRepairBadDelegationMember(BadDelegationMember badDelegationMember,
+                                                   String targetDelegationId, boolean newDelegationCreated) {
+        StringBuilder message = new StringBuilder();
+        message.append("Repaired bad delegation member ").append(badDelegationMember.toString());
+        if (newDelegationCreated) {
+            message.append(" New delegation created with id ").append(targetDelegationId)
+                    .append(" since there was no existing delegation that matched for the proper role id and delegation type.");
+        } else {
+            message.append(" Reassigned the delegation member to an existing delegation with id ")
+                    .append(targetDelegationId).append(" because it matched the proper role id and delegation type.");
+        }
+        return message.toString();
+    }
+
+    private String getNextDelegationId() {
+        DataFieldMaxValueIncrementer incrementer = MaxValueIncrementerFactory.getIncrementer(dataSource, "KRIM_DLGN_ID_S");
+        return incrementer.nextStringValue();
+    }
+
+
+    private List<DuplicateRoleDelegation> findDuplicateDelegations() {
+        return template.query(DUPLICATE_DELEGATIONS, new RowMapper<DuplicateRoleDelegation>() {
+            @Override
+            public DuplicateRoleDelegation mapRow(ResultSet resultSet, int i) throws SQLException {
+                return new DuplicateRoleDelegation(resultSet.getString(1), resultSet.getString(2),
+                        resultSet.getString(3), resultSet.getInt(4));
+            }
+        });
+    }
+
+    private List<BadDelegationMember> findBadDelegationMembers() {
+        return template.query(BAD_DELEGATION_MEMBERS, new RowMapper<BadDelegationMember>() {
+            @Override
+            public BadDelegationMember mapRow(ResultSet resultSet, int i) throws SQLException {
+                return new BadDelegationMember(resultSet.getString(1), resultSet.getString(2), resultSet.getString(3),
+                        resultSet.getString(4), resultSet.getString(5), resultSet.getString(6), resultSet.getString(7));
+            }
+        });
+    }
+
+    public void setDataSource(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    class DuplicateRoleDelegation {
+
+        final String roleId;
+        final String delegationTypeCode;
+        final String kimTypeId;
+        final int numMatching;
+
+        DuplicateRoleDelegation(String roleId, String delegationTypeCode, String kimTypeId, int numMatching) {
+            this.roleId = roleId;
+            this.delegationTypeCode = delegationTypeCode;
+            this.kimTypeId = kimTypeId;
+            this.numMatching = numMatching;
+        }
+
+        String report() {
+            return "Found duplicate role delegation " + toString();
+        }
+
+        public String toString() {
+            return String.format("[roleId = %s, delegationTypeCode = %s, kimTypeId = %s, num of matching delegations = %d]",
+                    roleId, delegationTypeCode, kimTypeId, numMatching);
+        }
+
+
+    }
+
+    class BadDelegationMember {
+
+        final String delegationMemberId;
+        final String roleMemberId;
+        final String roleMemberRoleId;
+        final String roleMemberRoleKimTypeId;
+        final String delegationId;
+        final String delegationRoleId;
+        final String delegationTypeCode;
+
+        BadDelegationMember(String delegationMemberId, String roleMemberId, String roleMemberRoleId,
+                            String roleMemberRoleKimTypeId, String delegationId, String delegationRoleId,
+                            String delegationTypeCode) {
+            this.delegationMemberId = delegationMemberId;
+            this.roleMemberId = roleMemberId;
+            this.roleMemberRoleId = roleMemberRoleId;
+            this.roleMemberRoleKimTypeId = roleMemberRoleKimTypeId;
+            this.delegationId = delegationId;
+            this.delegationRoleId = delegationRoleId;
+            this.delegationTypeCode = delegationTypeCode;
+        }
+
+        String report() {
+            return "Found bad delegation member " + toString();
+        }
+
+        public String toString() {
+            return String.format("[delegationMemberId = %s, roleMemberId = %s, " +
+                            "roleMemberRoleId = %s, roleMemberRoleKimTypeId = %s, delegationId = %s, " +
+                            "delegationRoleId = %s, delegationTypeCode = %s]",
+                    delegationMemberId, roleMemberId, roleMemberRoleId, roleMemberRoleKimTypeId, delegationId,
+                    delegationRoleId, delegationTypeCode);
+        }
+
+    }
+}

--- a/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/data/DataIntegrityServiceImpl.java
+++ b/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/data/DataIntegrityServiceImpl.java
@@ -13,6 +13,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * An implementation of DataIntegrityService which repairs two common data issues with delegations that occurred
+ * because of bad code in KIM.
+ *
+ * The first issue is one where duplicate delegations for a given role, delegation type, and KIM type exist. This can
+ * cause issues with the role document when editing delegations.
+ *
+ * The second issue is one where delegation members point to a role member for a role that doesn't match the role of
+ * their delegation.
+ *
+ * @author Eric Westfall
+ */
 public class DataIntegrityServiceImpl implements DataIntegrityService, InitializingBean {
 
     private static final String DUPLICATE_DELEGATIONS = "select role_id, dlgn_typ_cd, kim_typ_id, count(*) cnt from krim_dlgn_t where actv_ind = 'Y' group by role_id, dlgn_typ_cd, kim_typ_id having cnt > 1";

--- a/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/services/KimImplServiceLocator.java
+++ b/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/services/KimImplServiceLocator.java
@@ -21,6 +21,7 @@ import org.kuali.rice.core.api.config.property.ConfigContext;
 import org.kuali.rice.core.api.resourceloader.GlobalResourceLoader;
 import org.kuali.rice.kim.api.KimConstants;
 import org.kuali.rice.kim.framework.role.RoleTypeService;
+import org.kuali.rice.kim.impl.data.DataIntegrityService;
 import org.kuali.rice.kim.impl.group.GroupInternalService;
 import org.kuali.rice.kim.impl.responsibility.ResponsibilityInternalService;
 import org.kuali.rice.kim.impl.role.RoleDao;
@@ -39,6 +40,7 @@ public class KimImplServiceLocator {
     public static final String ROLE_INTERNAL_SERVICE = "kimRoleInternalService";
     public static final String LOCAL_CACHE_MANAGER = "kimLocalCacheManager";
     public static final String DEFAULT_ROLE_TYPE_SERVICE = "kimRoleTypeService";
+    public static final String DATA_INTEGRITY_SERVICE = "kimDataIntegrityService";
 
     public static final String KIM_ROLE_DAO = "kimRoleDao";
     public static final String KIM_DATA_SOURCE = "kimDataSource";
@@ -77,6 +79,10 @@ public class KimImplServiceLocator {
 
     public static RoleTypeService getDefaultRoleTypeService() {
         return (RoleTypeService) getService(DEFAULT_ROLE_TYPE_SERVICE);
+    }
+
+    public static DataIntegrityService getDataIntegrityService() {
+        return (DataIntegrityService) getService(DATA_INTEGRITY_SERVICE);
     }
 
     public static RoleDao getRoleDao() {

--- a/rice-middleware/kim/kim-impl/src/main/resources/org/kuali/rice/kim/impl/config/KimLocalSpringBeans.xml
+++ b/rice-middleware/kim/kim-impl/src/main/resources/org/kuali/rice/kim/impl/config/KimLocalSpringBeans.xml
@@ -24,6 +24,9 @@
   <import resource="classpath:org/kuali/rice/kim/impl/config/KimEmbeddedSpringBeans.xml"/>
   <import resource="classpath:org/kuali/rice/kim/impl/config/_KimServiceBusSpringBeans.xml"/>
 
+  <bean id="kimDataIntegrityService" class="org.kuali.rice.kim.impl.data.DataIntegrityServiceImpl"
+        p:dataSource-ref="kimDataSource"/>
+
   <!-- the distributed cache manager that calls into the kimCacheAdminService on the ksb -->
   <bean id="kimDistributedCacheManager" class="org.kuali.rice.core.impl.cache.DistributedCacheManagerDecorator"
         p:cacheManager-ref="kimLocalCacheManager"
@@ -56,6 +59,7 @@
       <list>
         <idref local="kimCacheDistributionQueue" />
         <idref local="kimDistributedCacheManager" />
+        <idref local="kimDataIntegrityService" />
       </list>
     </property>
   </bean>

--- a/rice-middleware/web/src/main/webapp/kim/WEB-INF/jsp/dataIntegrity.jsp
+++ b/rice-middleware/web/src/main/webapp/kim/WEB-INF/jsp/dataIntegrity.jsp
@@ -1,0 +1,44 @@
+<%@ include file="/kr/WEB-INF/jsp/tldHeader.jsp" %>
+
+<kul:page headerTitle="Data Integrity" lookup="true"
+          transactionalDocument="false" showDocumentInfo="false"
+          htmlFormAction="dataIntegrity" docTitle="Data Integrity">
+    <script>
+        function check() {
+            document.forms[0].elements['methodToCall'].value = 'check';
+            document.forms[0].submit();
+        }
+        function repair() {
+            document.forms[0].elements['methodToCall'].value = 'repair';
+            document.forms[0].submit();
+        }
+    </script>
+    <html-el:form action="dataIntegrity">
+        <html-el:hidden property="methodToCall" value=""/>
+        <div>
+            <input type="button" value="Run Data Check" onclick="check()"/>
+        </div>
+        <c:if test="${! empty checkMessages}">
+            <div>
+                <ul>
+                    <c:forEach var="message" items="${checkMessages}">
+                        <li><c:out value="${message}" escapeXml="true"/></li>
+                    </c:forEach>
+                </ul>
+            </div>
+        </c:if>
+        <div>
+            <input type="button" value="Run Data Repair" onclick="repair()"/>
+        </div>
+        <c:if test="${! empty repairMessages}">
+            <div>
+                <ul>
+                    <c:forEach var="message" items="${repairMessages}">
+                        <li><c:out value="${message}" escapeXml="true"/></li>
+                    </c:forEach>
+                </ul>
+            </div>
+        </c:if>
+    </html-el:form>
+
+</kul:page>

--- a/rice-middleware/web/src/main/webapp/kim/WEB-INF/jsp/dataIntegrity.jsp
+++ b/rice-middleware/web/src/main/webapp/kim/WEB-INF/jsp/dataIntegrity.jsp
@@ -13,32 +13,44 @@
             document.forms[0].submit();
         }
     </script>
+    <div class="headerarea" id="headerarea">
+        <h1>Data Integrity Repair Utility</h1>
+    </div>
     <html-el:form action="dataIntegrity">
         <html-el:hidden property="methodToCall" value=""/>
-        <div>
-            <input type="button" value="Run Data Check" onclick="check()"/>
-        </div>
-        <c:if test="${! empty checkMessages}">
+        <div style="margin-left:20px">
+            <p>Use the buttons below to run data integrity checks and repair on KIM delegation data.</p>
+            <br/>
+
             <div>
-                <ul>
-                    <c:forEach var="message" items="${checkMessages}">
-                        <li><c:out value="${message}" escapeXml="true"/></li>
-                    </c:forEach>
-                </ul>
+                <input type="button" value="Run Data Integrity Check" onclick="check()"/>
             </div>
-        </c:if>
-        <div>
-            <input type="button" value="Run Data Repair" onclick="repair()"/>
-        </div>
-        <c:if test="${! empty repairMessages}">
+            <br/>
+            <c:if test="${! empty checkMessages}">
+                <div>
+                    <ul>
+                        <c:forEach var="message" items="${checkMessages}">
+                            <li><c:out value="${message}" escapeXml="true"/></li>
+                        </c:forEach>
+                    </ul>
+                </div>
+                <br/>
+            </c:if>
             <div>
-                <ul>
-                    <c:forEach var="message" items="${repairMessages}">
-                        <li><c:out value="${message}" escapeXml="true"/></li>
-                    </c:forEach>
-                </ul>
+                <input type="button" value="Run Data Repair" onclick="repair()"/>
             </div>
-        </c:if>
+            <br/>
+            <c:if test="${! empty repairMessages}">
+                <div>
+                    <ul>
+                        <c:forEach var="message" items="${repairMessages}">
+                            <li><c:out value="${message}" escapeXml="true"/></li>
+                        </c:forEach>
+                    </ul>
+                </div>
+                <br/>
+            </c:if>
+        </div>
     </html-el:form>
 
 </kul:page>

--- a/rice-middleware/web/src/main/webapp/kim/WEB-INF/struts-config.xml
+++ b/rice-middleware/web/src/main/webapp/kim/WEB-INF/struts-config.xml
@@ -28,7 +28,8 @@
 	    <form-bean name="IdentityManagementPersonDocumentForm" type="org.kuali.rice.kim.web.struts.form.IdentityManagementPersonDocumentForm" />
 		<form-bean name="IdentityManagementRoleDocumentForm" type="org.kuali.rice.kim.web.struts.form.IdentityManagementRoleDocumentForm" />
 		<form-bean name="IdentityManagementGroupDocumentForm" type="org.kuali.rice.kim.web.struts.form.IdentityManagementGroupDocumentForm" />
-    </form-beans>
+		<form-bean name="DataIntegrityForm" type="org.kuali.rice.kim.web.struts.form.DataIntegrityForm" />
+	</form-beans>
 
 	<global-exceptions>
 		<!-- Begin required KNS exceptions -->
@@ -98,7 +99,10 @@
 			scope="request" parameter="methodToCall" validate="true" attribute="KualiForm">
 			<forward name="basic" path="/WEB-INF/jsp/identityManagementGroupDocument.jsp" />
 		</action>
-
+		<action path="/dataIntegrity" name="DataIntegrityForm" input="/WEB-INF/jsp/dataIntegrity.jsp" type="org.kuali.rice.kim.web.struts.action.DataIntegrityAction"
+				scope="request" parameter="methodToCall" validate="true" attribute="KualiForm">
+			<forward name="basic" path="/WEB-INF/jsp/dataIntegrity.jsp" />
+		</action>
     </action-mappings>
 
     <controller processorClass="org.kuali.rice.kns.web.struts.action.KualiRequestProcessor" />


### PR DESCRIPTION
This pull request implements a new simple screen for running KIM data integrity check and repair on delegation data. Specifically, there are a couple of data issues that crop up in delegation data related to bugs in that screen which were (hopefully) fixed as part of other work on the RICE-2 jira.

The url path for that screen is /kim/dataIntegrity.do