### PR TITLE
RICE-37 - fixed XSS issue in KRAD breadcrumbs

### DIFF
--- a/rice-framework/krad-web/src/main/webapp/krad/WEB-INF/ftl/components/widget/breadcrumb.ftl
+++ b/rice-framework/krad-web/src/main/webapp/krad/WEB-INF/ftl/components/widget/breadcrumb.ftl
@@ -26,7 +26,7 @@
     <#if element.render && element.label?has_content && element.label != "&nbsp;">
     <li>
         <#if element.renderAsLink>
-            <a ${id} data-role="breadcrumb" href="${element.url.href}" ${krad.attrBuild(element)}>${element.label}</a>
+            <a ${id} data-role="breadcrumb" href="${element.url.href?html}" ${krad.attrBuild(element)}>${element.label}</a>
         <#else>
             <span data-role="breadcrumb" ${id} ${krad.attrBuild(element)}>${element.label}</span>
         </#if>


### PR DESCRIPTION
Anytime an invalid url was sent to a controller it would echo it back in a breadcrumb when rendering the incident page, fix was to escape the html attribute properly in the breadcrumb.ftl