### PR TITLE
Rice 2.5 rice 49 xstream issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
     <xercesImpl.version>2.11.0</xercesImpl.version>
     <!-- need v. 1.4.01 of xml-apis with xercesImpl 2.11.0 -->
     <xml-apis.version>1.4.01</xml-apis.version>
-    <xmlunit.version>1.3</xmlunit.version>
+    <xmlunit.version>2.3.0</xmlunit.version>
     <xstream.version>1.4.9</xstream.version>
     <yuicompressor.version>2.4.7</yuicompressor.version>
 
@@ -2469,8 +2469,15 @@
       </dependency>
 
       <dependency>
-        <groupId>xmlunit</groupId>
-        <artifactId>xmlunit</artifactId>
+        <groupId>org.xmlunit</groupId>
+        <artifactId>xmlunit-core</artifactId>
+        <version>${xmlunit.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.xmlunit</groupId>
+        <artifactId>xmlunit-legacy</artifactId>
         <version>${xmlunit.version}</version>
         <scope>test</scope>
       </dependency>

--- a/rice-framework/krad-service-impl/pom.xml
+++ b/rice-framework/krad-service-impl/pom.xml
@@ -134,6 +134,20 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-legacy</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+
   </dependencies>
 
 </project>

--- a/rice-framework/krad-service-impl/src/main/java/org/kuali/rice/krad/service/impl/DataObjectSerializerServiceImpl.java
+++ b/rice-framework/krad-service-impl/src/main/java/org/kuali/rice/krad/service/impl/DataObjectSerializerServiceImpl.java
@@ -44,7 +44,6 @@ public class DataObjectSerializerServiceImpl extends SerializerServiceBase imple
                 return true;
             }
         };
-
         return evaluator;
     }
 

--- a/rice-framework/krad-service-impl/src/main/java/org/kuali/rice/krad/service/impl/DocumentSerializerServiceImpl.java
+++ b/rice-framework/krad-service-impl/src/main/java/org/kuali/rice/krad/service/impl/DocumentSerializerServiceImpl.java
@@ -36,23 +36,21 @@ public class DocumentSerializerServiceImpl extends SerializerServiceBase impleme
      * @see org.kuali.rice.krad.service.DocumentSerializerService#serializeDocumentToXmlForRouting(org.kuali.rice.krad.document.Document)
      */
     public String serializeDocumentToXmlForRouting(Document document) {
-        PropertySerializabilityEvaluator propertySerizabilityEvaluator = document.getDocumentPropertySerizabilityEvaluator();
-        evaluators.set(propertySerizabilityEvaluator);
-        //SerializationState state = createNewDocumentSerializationState(document);
-        //serializationStates.set(state);
-        
-        Object xmlWrapper = wrapDocumentWithMetadata(document);
-        String xml;
-        if (propertySerizabilityEvaluator instanceof AlwaysTruePropertySerializibilityEvaluator) {
-            xml = getXmlObjectSerializerService().toXml(xmlWrapper);
-        }
-        else {
-            xml = xstream.toXML(xmlWrapper);
-        }
-        
-        evaluators.set(null);
-        //serializationStates.set(null);
-        return xml;
+        final PropertySerializabilityEvaluator evaluator = document.getDocumentPropertySerizabilityEvaluator();
+        return doSerialization(evaluator, document, new Serializer<Document>() {
+            @Override
+            public String serialize(Document document) {
+                Object xmlWrapper = wrapDocumentWithMetadata(document);
+                String xml;
+                if (evaluator instanceof AlwaysTruePropertySerializibilityEvaluator) {
+                    xml = getXmlObjectSerializerService().toXml(xmlWrapper);
+                }
+                else {
+                    xml = xstream.toXML(xmlWrapper);
+                }
+                return xml;
+            }
+        });
     }
 
     /**

--- a/rice-framework/krad-service-impl/src/main/java/org/kuali/rice/krad/service/impl/DocumentSerializerServiceImpl.java
+++ b/rice-framework/krad-service-impl/src/main/java/org/kuali/rice/krad/service/impl/DocumentSerializerServiceImpl.java
@@ -20,7 +20,6 @@ import org.kuali.rice.krad.service.DocumentSerializerService;
 import org.kuali.rice.krad.service.XmlObjectSerializerService;
 import org.kuali.rice.krad.util.documentserializer.AlwaysTruePropertySerializibilityEvaluator;
 import org.kuali.rice.krad.util.documentserializer.PropertySerializabilityEvaluator;
-import org.kuali.rice.krad.util.documentserializer.SerializationState;
 
 /**
  * Default implementation of the {@link DocumentSerializerService}.  If no &lt;workflowProperties&gt; have been defined in the
@@ -39,8 +38,8 @@ public class DocumentSerializerServiceImpl extends SerializerServiceBase impleme
     public String serializeDocumentToXmlForRouting(Document document) {
         PropertySerializabilityEvaluator propertySerizabilityEvaluator = document.getDocumentPropertySerizabilityEvaluator();
         evaluators.set(propertySerizabilityEvaluator);
-        SerializationState state = createNewDocumentSerializationState(document);
-        serializationStates.set(state);
+        //SerializationState state = createNewDocumentSerializationState(document);
+        //serializationStates.set(state);
         
         Object xmlWrapper = wrapDocumentWithMetadata(document);
         String xml;
@@ -52,7 +51,7 @@ public class DocumentSerializerServiceImpl extends SerializerServiceBase impleme
         }
         
         evaluators.set(null);
-        serializationStates.set(null);
+        //serializationStates.set(null);
         return xml;
     }
 

--- a/rice-framework/krad-service-impl/src/main/java/org/kuali/rice/krad/service/impl/SerializerServiceBase.java
+++ b/rice-framework/krad-service-impl/src/main/java/org/kuali/rice/krad/service/impl/SerializerServiceBase.java
@@ -197,12 +197,13 @@ public abstract class SerializerServiceBase implements SerializerService  {
             String parentPathString = pathString.substring(0, indexOfLastSlash);
             SerializationState parentState = pathToSerializationState.get(parentPathString);
             if (parentState == null && parentPathString.isEmpty()) {
-                parentState = new SerializationState();
+                state = new SerializationState();
             } else if (parentState == null) {
-                throw new IllegalStateException("No parent state found");
+                throw new IllegalStateException("No parent state found for a parent path that should have it: " + parentPathString);
+            } else {
+                state = new SerializationState(parentState);
+                state.addSerializedProperty(pathTracker.peekElement(), evaluator.determinePropertyType(object));
             }
-            state = new SerializationState(parentState);
-            state.addSerializedProperty(pathTracker.peekElement(), evaluator.determinePropertyType(object));
             pathToSerializationState.put(pathString, state);
         }
         return state;

--- a/rice-framework/krad-service-impl/src/test/java/org/kuali/rice/krad/service/impl/DocumentSerializerServiceImplTest.java
+++ b/rice-framework/krad-service-impl/src/test/java/org/kuali/rice/krad/service/impl/DocumentSerializerServiceImplTest.java
@@ -124,6 +124,7 @@ public class DocumentSerializerServiceImplTest {
         document.setEvaluator(evaluator);
 
         xml = serializerService.serializeDocumentToXmlForRouting(document);
+        System.out.println(xml);
         XMLAssert.assertXMLEqual(COLLECTION_DOCUMENT_PARTIAL_XML_2, xml);
     }
 

--- a/rice-framework/krad-service-impl/src/test/java/org/kuali/rice/krad/service/impl/DocumentSerializerServiceImplTest.java
+++ b/rice-framework/krad-service-impl/src/test/java/org/kuali/rice/krad/service/impl/DocumentSerializerServiceImplTest.java
@@ -55,26 +55,22 @@ public class DocumentSerializerServiceImplTest {
 
         // now serialize it
 
-        String xml = serializerService.serializeDocumentToXmlForRouting(document);
-        XMLAssert.assertXMLEqual(SIMPLE_DOCUMENT_FULL_XML, xml);
-        System.out.println(xml);
+        //String xml = serializerService.serializeDocumentToXmlForRouting(document);
+        //XMLAssert.assertXMLEqual(SIMPLE_DOCUMENT_FULL_XML, xml);
+        //System.out.println(xml);
 
         // now let's try again with a partial set of things to serialize
 
         PropertySerializerTrie metadata = new PropertySerializerTrie();
-        metadata.addSerializablePropertyName("document", false);
         metadata.addSerializablePropertyName("document.documentProperty1", false);
         MetadataPropertySerializabilityEvaluator evaluator = new MetadataPropertySerializabilityEvaluator(metadata);
         document = new WrappedDocument(evaluator);
-        xml = serializerService.serializeDocumentToXmlForRouting(document);
-
-
-
-//        PropertySerializerTrie trie = new PropertySerializerTrie();
-//        trie.addSerializablePropertyName("documentProperty1");
-//        String xml = serializerService.serializeDocumentToXmlForRouting(document);
+        document.setDocumentProperty1("value1");
+        document.setDocumentProperty2(2);
+        String xml = serializerService.serializeDocumentToXmlForRouting(document);
         System.out.println(xml);
 
+        XMLAssert.assertXMLEqual(SIMPLE_DOCUMENT_PROPERTY_1, xml);
     }
 
     public static class WrappedDocument extends TransactionalDocumentBase {
@@ -470,6 +466,14 @@ public class DocumentSerializerServiceImplTest {
             .append("<documentProperty2>2</documentProperty2>")
             .append("</document>")
             .append("</org.kuali.rice.krad.workflow.KualiDocumentXmlMaterializer>").toString();
+
+    private static final String SIMPLE_DOCUMENT_PROPERTY_1 = new StringBuilder()
+            .append("<org.kuali.rice.krad.workflow.KualiDocumentXmlMaterializer>")
+            .append("<document class=\"org.kuali.rice.krad.service.impl.DocumentSerializerServiceImplTest$WrappedDocument\">")
+            .append("<documentProperty1>value1</documentProperty1>")
+            .append("</document>")
+            .append("</org.kuali.rice.krad.workflow.KualiDocumentXmlMaterializer>").toString();
+
 
 
 }

--- a/rice-framework/krad-service-impl/src/test/java/org/kuali/rice/krad/service/impl/DocumentSerializerServiceImplTest.java
+++ b/rice-framework/krad-service-impl/src/test/java/org/kuali/rice/krad/service/impl/DocumentSerializerServiceImplTest.java
@@ -1,0 +1,475 @@
+package org.kuali.rice.krad.service.impl;
+
+import org.custommonkey.xmlunit.XMLAssert;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.kim.api.identity.Person;
+import org.kuali.rice.krad.document.TransactionalDocumentBase;
+import org.kuali.rice.krad.service.LegacyDataAdapter;
+import org.kuali.rice.krad.service.XmlObjectSerializerService;
+import org.kuali.rice.krad.util.documentserializer.MetadataPropertySerializabilityEvaluator;
+import org.kuali.rice.krad.util.documentserializer.PropertySerializabilityEvaluator;
+import org.kuali.rice.krad.util.documentserializer.PropertySerializabilityEvaluatorBase;
+import org.kuali.rice.krad.util.documentserializer.PropertySerializerTrie;
+import org.kuali.rice.krad.util.documentserializer.SerializationState;
+import org.kuali.rice.krad.workflow.DocumentInitiator;
+import org.kuali.rice.krad.workflow.KualiDocumentXmlMaterializer;
+import org.kuali.rice.krad.workflow.KualiTransactionalDocumentInformation;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit test for {@link DocumentSerializerServiceImpl}
+ *
+ * @author Eric Westfall
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DocumentSerializerServiceImplTest {
+
+    @Mock
+    private LegacyDataAdapter legacyDataAdapter;
+    @Mock
+    private XmlObjectSerializerService xmlObjectSerializerService;
+
+    @InjectMocks
+    private DocumentSerializerServiceImpl serializerService = new DocumentSerializerServiceImpl();
+
+    @Before
+    public void setup() {
+        XMLUnit.setIgnoreWhitespace(true);
+    }
+
+    @Test
+    public void testSerializeDocumentToXmlForRouting_TopLevelPropertyInclusion() throws Exception {
+        // set up a simple document that is set up with a serializability evaluator that serializes everything
+        WrappedDocument document = new WrappedDocument(new MakeItSoPropertySerializibilityEvaluator());
+        document.setDocumentProperty1("value1");
+        document.setDocumentProperty2(2);
+
+        // now serialize it
+
+        String xml = serializerService.serializeDocumentToXmlForRouting(document);
+        XMLAssert.assertXMLEqual(SIMPLE_DOCUMENT_FULL_XML, xml);
+        System.out.println(xml);
+
+        // now let's try again with a partial set of things to serialize
+
+        PropertySerializerTrie metadata = new PropertySerializerTrie();
+        metadata.addSerializablePropertyName("document", false);
+        metadata.addSerializablePropertyName("document.documentProperty1", false);
+        MetadataPropertySerializabilityEvaluator evaluator = new MetadataPropertySerializabilityEvaluator(metadata);
+        document = new WrappedDocument(evaluator);
+        xml = serializerService.serializeDocumentToXmlForRouting(document);
+
+
+
+//        PropertySerializerTrie trie = new PropertySerializerTrie();
+//        trie.addSerializablePropertyName("documentProperty1");
+//        String xml = serializerService.serializeDocumentToXmlForRouting(document);
+        System.out.println(xml);
+
+    }
+
+    public static class WrappedDocument extends TransactionalDocumentBase {
+
+        private String documentProperty1;
+        private int documentProperty2;
+        private Child child1;
+        private Child child2;
+        private Child child3;
+
+        private transient PropertySerializabilityEvaluator evaluator;
+
+        public WrappedDocument(PropertySerializabilityEvaluator evaluator) {
+            this.evaluator = evaluator;
+        }
+
+        public void setEvaluator(PropertySerializabilityEvaluator evaluator) {
+            this.evaluator = evaluator;
+        }
+
+        @Override
+        public KualiDocumentXmlMaterializer wrapDocumentWithMetadataForXmlSerialization() {
+            KualiTransactionalDocumentInformation transInfo = new KualiTransactionalDocumentInformation();
+            DocumentInitiator initiator = new DocumentInitiator();
+            initiator.setPerson(new MockPerson("johndoe"));
+            transInfo.setDocumentInitiator(initiator);
+            KualiDocumentXmlMaterializer xmlWrapper = new KualiDocumentXmlMaterializer();
+            xmlWrapper.setDocument(this);
+            xmlWrapper.setKualiTransactionalDocumentInformation(transInfo);
+            return xmlWrapper;
+        }
+
+        @Override
+        public PropertySerializabilityEvaluator getDocumentPropertySerizabilityEvaluator() {
+            return evaluator;
+        }
+
+        public String getDocumentProperty1() {
+            return documentProperty1;
+        }
+
+        public void setDocumentProperty1(String documentProperty1) {
+            this.documentProperty1 = documentProperty1;
+        }
+
+        public int getDocumentProperty2() {
+            return documentProperty2;
+        }
+
+        public void setDocumentProperty2(int documentProperty2) {
+            this.documentProperty2 = documentProperty2;
+        }
+
+        public Child getChild1() {
+            return child1;
+        }
+
+        public void setChild1(Child child1) {
+            this.child1 = child1;
+        }
+
+        public Child getChild2() {
+            return child2;
+        }
+
+        public void setChild2(Child child2) {
+            this.child2 = child2;
+        }
+
+        public Child getChild3() {
+            return child3;
+        }
+
+        public void setChild3(Child child3) {
+            this.child3 = child3;
+        }
+    }
+
+    public static class Child {
+
+        private String property1;
+        private Grandchild grandchild1;
+        private Grandchild grandchild2;
+        private Grandchild grandchild3;
+
+        public String getProperty1() {
+            return property1;
+        }
+
+        public void setProperty1(String property1) {
+            this.property1 = property1;
+        }
+
+        public Grandchild getGrandchild1() {
+            return grandchild1;
+        }
+
+        public void setGrandchild1(Grandchild grandchild1) {
+            this.grandchild1 = grandchild1;
+        }
+
+        public Grandchild getGrandchild2() {
+            return grandchild2;
+        }
+
+        public void setGrandchild2(Grandchild grandchild2) {
+            this.grandchild2 = grandchild2;
+        }
+
+        public Grandchild getGrandchild3() {
+            return grandchild3;
+        }
+
+        public void setGrandchild3(Grandchild grandchild3) {
+            this.grandchild3 = grandchild3;
+        }
+    }
+
+    public static class Grandchild {
+
+        private String property1;
+        private boolean property2;
+
+        public String getProperty1() {
+            return property1;
+        }
+
+        public void setProperty1(String property1) {
+            this.property1 = property1;
+        }
+
+        public boolean isProperty2() {
+            return property2;
+        }
+
+        public void setProperty2(boolean property2) {
+            this.property2 = property2;
+        }
+    }
+
+    public static class MakeItSoPropertySerializibilityEvaluator extends PropertySerializabilityEvaluatorBase {
+        @Override
+        public boolean isPropertySerializable(SerializationState state, Object containingObject, String childPropertyName, Object childPropertyValue) {
+            // make it so...
+            return true;
+        }
+    }
+
+    public static class MockPerson implements Person {
+
+        private static final long serialVersionUID = 5330488987382249417L;
+
+        private final String id;
+
+        public MockPerson() {
+            id = null;
+        }
+
+        MockPerson(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public void refresh() {}
+
+        @Override
+        public String getPrincipalId() {
+            return id;
+        }
+
+        @Override
+        public String getPrincipalName() {
+            return id;
+        }
+
+        @Override
+        public String getEntityId() {
+            return id;
+        }
+
+        @Override
+        public String getEntityTypeCode() {
+            return null;
+        }
+
+        @Override
+        public String getFirstName() {
+            return "Test";
+        }
+
+        @Override
+        public String getFirstNameUnmasked() {
+            return "Test";
+        }
+
+        @Override
+        public String getMiddleName() {
+            return "User";
+        }
+
+        @Override
+        public String getMiddleNameUnmasked() {
+            return "User";
+        }
+
+        @Override
+        public String getLastName() {
+            return id;
+        }
+
+        @Override
+        public String getLastNameUnmasked() {
+            return id;
+        }
+
+        @Override
+        public String getName() {
+            return "Test User " + id;
+        }
+
+        @Override
+        public String getNameUnmasked() {
+            return "Test User " + id;
+        }
+
+        @Override
+        public String getEmailAddress() {
+            return null;
+        }
+
+        @Override
+        public String getEmailAddressUnmasked() {
+            return null;
+        }
+
+        @Override
+        public String getAddressLine1() {
+            return null;
+        }
+
+        @Override
+        public String getAddressLine1Unmasked() {
+            return null;
+        }
+
+        @Override
+        public String getAddressLine2() {
+            return null;
+        }
+
+        @Override
+        public String getAddressLine2Unmasked() {
+            return null;
+        }
+
+        @Override
+        public String getAddressLine3() {
+            return null;
+        }
+
+        @Override
+        public String getAddressLine3Unmasked() {
+            return null;
+        }
+
+        @Override
+        public String getAddressCity() {
+            return null;
+        }
+
+        @Override
+        public String getAddressCityUnmasked() {
+            return null;
+        }
+
+        @Override
+        public String getAddressStateProvinceCode() {
+            return null;
+        }
+
+        @Override
+        public String getAddressStateProvinceCodeUnmasked() {
+            return null;
+        }
+
+        @Override
+        public String getAddressPostalCode() {
+            return null;
+        }
+
+        @Override
+        public String getAddressPostalCodeUnmasked() {
+            return null;
+        }
+
+        @Override
+        public String getAddressCountryCode() {
+            return null;
+        }
+
+        @Override
+        public String getAddressCountryCodeUnmasked() {
+            return null;
+        }
+
+        @Override
+        public String getPhoneNumber() {
+            return null;
+        }
+
+        @Override
+        public String getPhoneNumberUnmasked() {
+            return null;
+        }
+
+        @Override
+        public String getCampusCode() {
+            return null;
+        }
+
+        @Override
+        public Map<String, String> getExternalIdentifiers() {
+            return null;
+        }
+
+        @Override
+        public boolean hasAffiliationOfType(String affiliationTypeCode) {
+            return false;
+        }
+
+        @Override
+        public List<String> getCampusCodesForAffiliationOfType(String affiliationTypeCode) {
+            return null;
+        }
+
+        @Override
+        public String getEmployeeStatusCode() {
+            return null;
+        }
+
+        @Override
+        public String getEmployeeTypeCode() {
+            return null;
+        }
+
+        @Override
+        public KualiDecimal getBaseSalaryAmount() {
+            return null;
+        }
+
+        @Override
+        public String getExternalId(String externalIdentifierTypeCode) {
+            return null;
+        }
+
+        @Override
+        public String getPrimaryDepartmentCode() {
+            return null;
+        }
+
+        @Override
+        public String getEmployeeId() {
+            return null;
+        }
+
+        @Override
+        public boolean isActive() {
+            return true;
+        }
+
+    }
+
+    private static final String SIMPLE_DOCUMENT_FULL_XML = new StringBuilder()
+            .append("<org.kuali.rice.krad.workflow.KualiDocumentXmlMaterializer>")
+            .append("<kualiTransactionalDocumentInformation>")
+            .append("<documentInitiator>")
+            .append("<person class=\"org.kuali.rice.krad.service.impl.DocumentSerializerServiceImplTest$MockPerson\">")
+            .append("<id>johndoe</id>")
+            .append("</person>")
+            .append("</documentInitiator>")
+            .append("</kualiTransactionalDocumentInformation>")
+            .append("<document class=\"org.kuali.rice.krad.service.impl.DocumentSerializerServiceImplTest$WrappedDocument\">")
+            .append("<newCollectionRecord>false</newCollectionRecord>")
+            .append("<documentHeader>")
+            .append("<newCollectionRecord>false</newCollectionRecord>")
+            .append("</documentHeader>")
+            .append("<pessimisticLocks/>")
+            .append("<adHocRoutePersons/>")
+            .append("<adHocRouteWorkgroups/>")
+            .append("<notes/>")
+            .append("<superUserAnnotation></superUserAnnotation>")
+            .append("<documentProperty1>value1</documentProperty1>")
+            .append("<documentProperty2>2</documentProperty2>")
+            .append("</document>")
+            .append("</org.kuali.rice.krad.workflow.KualiDocumentXmlMaterializer>").toString();
+
+
+}

--- a/rice-framework/krad-service-impl/src/test/java/org/kuali/rice/krad/service/impl/DocumentSerializerServiceImplTest.java
+++ b/rice-framework/krad-service-impl/src/test/java/org/kuali/rice/krad/service/impl/DocumentSerializerServiceImplTest.java
@@ -55,9 +55,8 @@ public class DocumentSerializerServiceImplTest {
 
         // now serialize it
 
-        //String xml = serializerService.serializeDocumentToXmlForRouting(document);
-        //XMLAssert.assertXMLEqual(SIMPLE_DOCUMENT_FULL_XML, xml);
-        //System.out.println(xml);
+        String xml = serializerService.serializeDocumentToXmlForRouting(document);
+        XMLAssert.assertXMLEqual(SIMPLE_DOCUMENT_FULL_XML, xml);
 
         // now let's try again with a partial set of things to serialize
 
@@ -67,9 +66,8 @@ public class DocumentSerializerServiceImplTest {
         document = new WrappedDocument(evaluator);
         document.setDocumentProperty1("value1");
         document.setDocumentProperty2(2);
-        String xml = serializerService.serializeDocumentToXmlForRouting(document);
-        System.out.println(xml);
 
+        xml = serializerService.serializeDocumentToXmlForRouting(document);
         XMLAssert.assertXMLEqual(SIMPLE_DOCUMENT_PROPERTY_1, xml);
     }
 

--- a/rice-framework/krad-service-impl/src/test/java/org/kuali/rice/krad/service/impl/DocumentSerializerServiceImplTest.java
+++ b/rice-framework/krad-service-impl/src/test/java/org/kuali/rice/krad/service/impl/DocumentSerializerServiceImplTest.java
@@ -71,6 +71,80 @@ public class DocumentSerializerServiceImplTest {
         XMLAssert.assertXMLEqual(SIMPLE_DOCUMENT_PROPERTY_1, xml);
     }
 
+    @Test
+    public void testSerializeDocumentToXmlForRouting_DeepObjectGraph() throws Exception {
+        // set up a simple document that is set up with a serializability evaluator that serializes everything
+        WrappedDocument document = setupDeepDocument();
+        document.setEvaluator(new MakeItSoPropertySerializibilityEvaluator());
+        // now serialize it
+
+        String xml = serializerService.serializeDocumentToXmlForRouting(document);
+        XMLAssert.assertXMLEqual(DEEP_DOCUMENT_FULL_XML, xml);
+
+        // now let's try again with a partial set of things to serialize
+
+        PropertySerializerTrie metadata = new PropertySerializerTrie();
+        metadata.addSerializablePropertyName("document.child1", false);
+        metadata.addSerializablePropertyName("document.child2.grandchild2", false);
+        metadata.addSerializablePropertyName("document.child2.grandchild3", false);
+        MetadataPropertySerializabilityEvaluator evaluator = new MetadataPropertySerializabilityEvaluator(metadata);
+        document.setEvaluator(evaluator);
+
+        xml = serializerService.serializeDocumentToXmlForRouting(document);
+        XMLAssert.assertXMLEqual(DEEP_DOCUMENT_PARTIAL_XML, xml);
+    }
+
+    private WrappedDocument setupDeepDocument() {
+        WrappedDocument document = new WrappedDocument(new MakeItSoPropertySerializibilityEvaluator());
+        document.setDocumentProperty1("value1");
+        document.setDocumentProperty2(1);
+
+        // child 1
+        Child child1 = new Child();
+        document.setChild1(child1);
+        child1.setProperty1("child1property1");
+        Grandchild child1grandchild1 = new Grandchild();
+        Grandchild child1grandchild2 = new Grandchild();
+        Grandchild child1grandchild3 = new Grandchild();
+        child1.setGrandchild1(child1grandchild1);
+        child1.setGrandchild2(child1grandchild2);
+        child1.setGrandchild3(child1grandchild3);
+
+        // grandchild1
+        child1grandchild1.setProperty1("child1grandchild1");
+        child1grandchild1.setProperty2(true);
+        // grandchild2
+        child1grandchild2.setProperty1("child1grandchild2");
+        child1grandchild2.setProperty2(false);
+        // grandchild3
+        child1grandchild3.setProperty1("child1grandchild3");
+        child1grandchild3.setProperty2(true);
+
+        // child 2
+        Child child2 = new Child();
+        document.setChild2(child2);
+        child2.setProperty1("child2property1");
+        Grandchild child2grandchild1 = new Grandchild();
+        Grandchild child2grandchild2 = new Grandchild();
+        Grandchild child2grandchild3 = new Grandchild();
+        child2.setGrandchild1(child2grandchild1);
+        child2.setGrandchild2(child2grandchild2);
+        child2.setGrandchild3(child2grandchild3);
+
+        // grandchild1
+        child2grandchild1.setProperty1("child2grandchild1");
+        child2grandchild1.setProperty2(false);
+        // grandchild2
+        child2grandchild2.setProperty1("child2grandchild2");
+        child2grandchild2.setProperty2(true);
+        // grandchild3
+        child2grandchild3.setProperty1("child2grandchild3");
+        child2grandchild3.setProperty2(false);
+
+        return document;
+    }
+
+
     public static class WrappedDocument extends TransactionalDocumentBase {
 
         private String documentProperty1;
@@ -443,35 +517,122 @@ public class DocumentSerializerServiceImplTest {
 
     private static final String SIMPLE_DOCUMENT_FULL_XML = new StringBuilder()
             .append("<org.kuali.rice.krad.workflow.KualiDocumentXmlMaterializer>")
-            .append("<kualiTransactionalDocumentInformation>")
-            .append("<documentInitiator>")
-            .append("<person class=\"org.kuali.rice.krad.service.impl.DocumentSerializerServiceImplTest$MockPerson\">")
-            .append("<id>johndoe</id>")
-            .append("</person>")
-            .append("</documentInitiator>")
-            .append("</kualiTransactionalDocumentInformation>")
-            .append("<document class=\"org.kuali.rice.krad.service.impl.DocumentSerializerServiceImplTest$WrappedDocument\">")
-            .append("<newCollectionRecord>false</newCollectionRecord>")
-            .append("<documentHeader>")
-            .append("<newCollectionRecord>false</newCollectionRecord>")
-            .append("</documentHeader>")
-            .append("<pessimisticLocks/>")
-            .append("<adHocRoutePersons/>")
-            .append("<adHocRouteWorkgroups/>")
-            .append("<notes/>")
-            .append("<superUserAnnotation></superUserAnnotation>")
-            .append("<documentProperty1>value1</documentProperty1>")
-            .append("<documentProperty2>2</documentProperty2>")
-            .append("</document>")
-            .append("</org.kuali.rice.krad.workflow.KualiDocumentXmlMaterializer>").toString();
+            .append("  <kualiTransactionalDocumentInformation>")
+            .append("    <documentInitiator>")
+            .append("      <person class=\"org.kuali.rice.krad.service.impl.DocumentSerializerServiceImplTest$MockPerson\">")
+            .append("        <id>johndoe</id>")
+            .append("      </person>")
+            .append("    </documentInitiator>")
+            .append("  </kualiTransactionalDocumentInformation>")
+            .append("  <document class=\"org.kuali.rice.krad.service.impl.DocumentSerializerServiceImplTest$WrappedDocument\">")
+            .append("    <documentProperty1>value1</documentProperty1>")
+            .append("    <documentProperty2>2</documentProperty2>")
+            .append("    <documentHeader>")
+            .append("      <newCollectionRecord>false</newCollectionRecord>")
+            .append("    </documentHeader>")
+            .append("    <pessimisticLocks/>")
+            .append("    <adHocRoutePersons/>")
+            .append("    <adHocRouteWorkgroups/>")
+            .append("    <notes/>")
+            .append("    <superUserAnnotation></superUserAnnotation>")
+            .append("    <newCollectionRecord>false</newCollectionRecord>")
+            .append("  </document>")
+            .append("</org.kuali.rice.krad.workflow.KualiDocumentXmlMaterializer>")
+            .toString();
 
     private static final String SIMPLE_DOCUMENT_PROPERTY_1 = new StringBuilder()
             .append("<org.kuali.rice.krad.workflow.KualiDocumentXmlMaterializer>")
-            .append("<document class=\"org.kuali.rice.krad.service.impl.DocumentSerializerServiceImplTest$WrappedDocument\">")
-            .append("<documentProperty1>value1</documentProperty1>")
-            .append("</document>")
-            .append("</org.kuali.rice.krad.workflow.KualiDocumentXmlMaterializer>").toString();
+            .append("  <document class=\"org.kuali.rice.krad.service.impl.DocumentSerializerServiceImplTest$WrappedDocument\">")
+            .append("    <documentProperty1>value1</documentProperty1>")
+            .append("  </document>")
+            .append("</org.kuali.rice.krad.workflow.KualiDocumentXmlMaterializer>")
+            .toString();
 
+    private static final String DEEP_DOCUMENT_FULL_XML = new StringBuilder()
+            .append("<org.kuali.rice.krad.workflow.KualiDocumentXmlMaterializer>")
+            .append("  <kualiTransactionalDocumentInformation>")
+            .append("    <documentInitiator>")
+            .append("      <person class=\"org.kuali.rice.krad.service.impl.DocumentSerializerServiceImplTest$MockPerson\">")
+            .append("        <id>johndoe</id>")
+            .append("      </person>")
+            .append("    </documentInitiator>")
+            .append("  </kualiTransactionalDocumentInformation>")
+            .append("  <document class=\"org.kuali.rice.krad.service.impl.DocumentSerializerServiceImplTest$WrappedDocument\">")
+            .append("    <documentProperty1>value1</documentProperty1>")
+            .append("    <documentProperty2>1</documentProperty2>")
+            .append("    <child1>")
+            .append("      <property1>child1property1</property1>")
+            .append("      <grandchild1>")
+            .append("        <property1>child1grandchild1</property1>")
+            .append("        <property2>true</property2>")
+            .append("      </grandchild1>")
+            .append("      <grandchild2>")
+            .append("        <property1>child1grandchild2</property1>")
+            .append("        <property2>false</property2>")
+            .append("      </grandchild2>")
+            .append("      <grandchild3>")
+            .append("        <property1>child1grandchild3</property1>")
+            .append("        <property2>true</property2>")
+            .append("      </grandchild3>")
+            .append("    </child1>")
+            .append("    <child2>")
+            .append("      <property1>child2property1</property1>")
+            .append("      <grandchild1>")
+            .append("        <property1>child2grandchild1</property1>")
+            .append("        <property2>false</property2>")
+            .append("      </grandchild1>")
+            .append("      <grandchild2>")
+            .append("        <property1>child2grandchild2</property1>")
+            .append("        <property2>true</property2>")
+            .append("      </grandchild2>")
+            .append("      <grandchild3>")
+            .append("        <property1>child2grandchild3</property1>")
+            .append("        <property2>false</property2>")
+            .append("      </grandchild3>")
+            .append("    </child2>")
+            .append("    <documentHeader>")
+            .append("      <newCollectionRecord>false</newCollectionRecord>")
+            .append("    </documentHeader>")
+            .append("    <pessimisticLocks/>")
+            .append("    <adHocRoutePersons/>")
+            .append("    <adHocRouteWorkgroups/>")
+            .append("    <notes/>")
+            .append("    <superUserAnnotation></superUserAnnotation>")
+            .append("    <newCollectionRecord>false</newCollectionRecord>")
+            .append("  </document>")
+            .append("</org.kuali.rice.krad.workflow.KualiDocumentXmlMaterializer>")
+            .toString();
 
+    private static final String DEEP_DOCUMENT_PARTIAL_XML = new StringBuilder()
+            .append("<org.kuali.rice.krad.workflow.KualiDocumentXmlMaterializer>")
+            .append("  <document class=\"org.kuali.rice.krad.service.impl.DocumentSerializerServiceImplTest$WrappedDocument\">")
+            .append("    <child1>")
+            .append("      <property1>child1property1</property1>")
+            .append("      <grandchild1>")
+            .append("        <property1>child1grandchild1</property1>")
+            .append("        <property2>true</property2>")
+            .append("      </grandchild1>")
+            .append("      <grandchild2>")
+            .append("        <property1>child1grandchild2</property1>")
+            .append("        <property2>false</property2>")
+            .append("      </grandchild2>")
+            .append("      <grandchild3>")
+            .append("        <property1>child1grandchild3</property1>")
+            .append("        <property2>true</property2>")
+            .append("      </grandchild3>")
+            .append("    </child1>")
+            .append("    <child2>")
+            .append("      <grandchild2>")
+            .append("        <property1>child2grandchild2</property1>")
+            .append("        <property2>true</property2>")
+            .append("      </grandchild2>")
+            .append("      <grandchild3>")
+            .append("        <property1>child2grandchild3</property1>")
+            .append("        <property2>false</property2>")
+            .append("      </grandchild3>")
+            .append("    </child2>")
+            .append("  </document>")
+            .append("</org.kuali.rice.krad.workflow.KualiDocumentXmlMaterializer>")
+            .toString();
 
 }

--- a/rice-framework/krad-web-framework/src/main/java/org/kuali/rice/krad/util/documentserializer/MetadataPropertySerializabilityEvaluator.java
+++ b/rice-framework/krad-web-framework/src/main/java/org/kuali/rice/krad/util/documentserializer/MetadataPropertySerializabilityEvaluator.java
@@ -1,0 +1,18 @@
+package org.kuali.rice.krad.util.documentserializer;
+
+/**
+ * A very simple implement of {@link PropertySerializabilityEvaluator} which simply uses the
+ * provided {@link PropertySerializerTrie} as metadata to define what should be serialized.
+ *
+ * @author Eric Westfall
+ */
+public class MetadataPropertySerializabilityEvaluator extends PropertySerializabilityEvaluatorBase {
+
+    public MetadataPropertySerializabilityEvaluator(PropertySerializerTrie metadata) {
+        if (metadata == null) {
+            throw new IllegalArgumentException("metadata is required but was null");
+        }
+        this.serializableProperties = metadata;
+    }
+
+}

--- a/rice-framework/krad-web-framework/src/main/java/org/kuali/rice/krad/util/documentserializer/MetadataPropertySerializabilityEvaluator.java
+++ b/rice-framework/krad-web-framework/src/main/java/org/kuali/rice/krad/util/documentserializer/MetadataPropertySerializabilityEvaluator.java
@@ -1,7 +1,7 @@
 package org.kuali.rice.krad.util.documentserializer;
 
 /**
- * A very simple implement of {@link PropertySerializabilityEvaluator} which simply uses the
+ * A very simple implementation of {@link PropertySerializabilityEvaluator} which simply uses the
  * provided {@link PropertySerializerTrie} as metadata to define what should be serialized.
  *
  * @author Eric Westfall

--- a/rice-framework/krad-web-framework/src/main/java/org/kuali/rice/krad/util/documentserializer/SerializationState.java
+++ b/rice-framework/krad-web-framework/src/main/java/org/kuali/rice/krad/util/documentserializer/SerializationState.java
@@ -52,6 +52,11 @@ public class SerializationState {
         pathElements = new ArrayList<SerializationPropertyElement>();
     }
 
+    /**
+     * Creates a new SerializationState that is a copy of the given state
+     *
+     * @param stateToCopy the state to copy
+     */
     public SerializationState(SerializationState stateToCopy) {
         this();
         this.pathElements.addAll(stateToCopy.pathElements);

--- a/rice-framework/krad-web-framework/src/main/java/org/kuali/rice/krad/util/documentserializer/SerializationState.java
+++ b/rice-framework/krad-web-framework/src/main/java/org/kuali/rice/krad/util/documentserializer/SerializationState.java
@@ -52,6 +52,11 @@ public class SerializationState {
         pathElements = new ArrayList<SerializationPropertyElement>();
     }
 
+    public SerializationState(SerializationState stateToCopy) {
+        this();
+        this.pathElements.addAll(stateToCopy.pathElements);
+    }
+
     /**
      * The number of property elements in this state object.
      *

--- a/rice-middleware/it/edl/pom.xml
+++ b/rice-middleware/it/edl/pom.xml
@@ -162,11 +162,6 @@
       <artifactId>subethasmtp</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>xmlunit</groupId>
-      <artifactId>xmlunit</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/rice-middleware/it/kew/pom.xml
+++ b/rice-middleware/it/kew/pom.xml
@@ -206,8 +206,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>xmlunit</groupId>
-      <artifactId>xmlunit</artifactId>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-legacy</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/rice-middleware/it/kew/src/test/java/org/kuali/rice/kew/postprocessor/PostProcessorTest.java
+++ b/rice-middleware/it/kew/src/test/java/org/kuali/rice/kew/postprocessor/PostProcessorTest.java
@@ -15,19 +15,11 @@
  */
 package org.kuali.rice.kew.postprocessor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.commons.lang.StringUtils;
 import org.custommonkey.xmlunit.XMLAssert;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Test;
+import org.kuali.rice.kew.api.KewApiConstants;
 import org.kuali.rice.kew.api.WorkflowDocument;
 import org.kuali.rice.kew.api.WorkflowDocumentFactory;
 import org.kuali.rice.kew.api.action.ActionRequestType;
@@ -40,11 +32,18 @@ import org.kuali.rice.kew.framework.postprocessor.ProcessDocReport;
 import org.kuali.rice.kew.routeheader.DocumentRouteHeaderValue;
 import org.kuali.rice.kew.service.KEWServiceLocator;
 import org.kuali.rice.kew.test.KEWTestCase;
-import org.kuali.rice.kew.api.KewApiConstants;
 import org.kuali.rice.test.BaselineTestCase;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @BaselineTestCase.BaselineMode(BaselineTestCase.Mode.NONE)
 public class PostProcessorTest extends KEWTestCase {


### PR DESCRIPTION
This is to address RICE-49 whereby serialization was not working properly for workflow XML when property serializability evaluators are used.

The basic issue was related to an upgrade in the version of XStream that made the method for tracking the context around serialization state no longer valid.

This pull requests modifies the code to use an internal XStream api called "PathTracker" to determine context when the visitSerializableFields method is called. The majority of code for this is in SerializerServiceBase. I also implemented a unit test (DocumentSerializerServiceImplTest) to test a few different XStream serialization scenarios using this technique to ensure they behave as expected. Note that I wrote these tests also against the "old" version of XStream (1.2.2) and executed them there so the behavior for these test cases should be *identical* between the two versions. I tried to test a number of different serialization scenarios in the unit test but I think a real test against KFS and/or KC objects will be the most telling.

Note that the main implication of this implementation is that it likely results in a higher memory consumption during serialization since it is populating a Map that maps paths from the PathTracker to SerializationState objects. However, the implementation does reuse the SerializationPropertyElement instances that make up the object graph so hopefully this will not be a large impact.

One last thing to mention is that there is an impacting change here. I removed the ThreadLocal that stored SerializationState which was a protected variable on SerializerServiceBase and being managed in some of the subclasses of SerializerServiceBase. I updated those subclasses to handle things appropriately, but if other applications have subclasses of SerializerServiceBase (i'm not sure if any do) then those will need to be updated in a similar fashion.