### PR TITLE
Fixed bug in date diff code on DST boundary

### DIFF
--- a/rice-framework/krad-it/src/test/java/org/kuali/rice/krad/service/DateTimeServiceTest.java
+++ b/rice-framework/krad-it/src/test/java/org/kuali/rice/krad/service/DateTimeServiceTest.java
@@ -340,4 +340,35 @@ public class DateTimeServiceTest extends KRADTestCase {
 
         assertEquals("-5", Integer.toString(CoreApiServiceLocator.getDateTimeService().dateDiff(date1, date2, false)));
     }
+
+    /**
+     * Tests {@link org.kuali.rice.core.api.datetime.DateTimeService#dateDiff(java.util.Date, java.util.Date, boolean)} with dates on or
+     * near the daylight savings time boundary, and with the inclusive flag set to "true". Daylight savings time began on 3/12 in 2017,
+     * so these dates were chosen because they originally exhibited incorrect behavior in relation to the DST date.
+     *
+     * @throws ParseException
+     */
+    @Test public void testDateDiffDaylightSavingsTimeInclusive() throws ParseException {
+        SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy");
+
+        Date date1 = sdf.parse("03/13/2017");
+        Date date2 = sdf.parse("03/13/2017");
+
+        assertEquals(1, CoreApiServiceLocator.getDateTimeService().dateDiff(date1, date2, true));
+
+        date1 = sdf.parse("03/13/2017");
+        date2 = sdf.parse("03/14/2017");
+
+        assertEquals(2, CoreApiServiceLocator.getDateTimeService().dateDiff(date1, date2, true));
+
+        date1 = sdf.parse("03/12/2017");
+        date2 = sdf.parse("03/13/2017");
+
+        assertEquals(2, CoreApiServiceLocator.getDateTimeService().dateDiff(date1, date2, true));
+
+        date1 = sdf.parse("03/13/2017");
+        date2 = sdf.parse("03/12/2017");
+
+        assertEquals(-2, CoreApiServiceLocator.getDateTimeService().dateDiff(date1, date2, true));
+    }
 }

--- a/rice-middleware/core/impl/src/main/java/org/kuali/rice/core/impl/datetime/DateTimeServiceImpl.java
+++ b/rice-middleware/core/impl/src/main/java/org/kuali/rice/core/impl/datetime/DateTimeServiceImpl.java
@@ -16,11 +16,10 @@
 package org.kuali.rice.core.impl.datetime;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.time.DurationFormatUtils;
 import org.joda.time.DateTime;
-import org.kuali.rice.core.api.datetime.DateTimeService;
 import org.kuali.rice.core.api.CoreConstants;
 import org.kuali.rice.core.api.config.property.ConfigContext;
+import org.kuali.rice.core.api.datetime.DateTimeService;
 import org.springframework.beans.factory.InitializingBean;
 
 import java.sql.Time;
@@ -29,6 +28,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
@@ -227,32 +227,11 @@ public class DateTimeServiceImpl implements DateTimeService, InitializingBean {
 	}
 
 	public int dateDiff(Date startDate, Date endDate, boolean inclusive) {
-		Calendar startDateCalendar = Calendar.getInstance();
-		startDateCalendar.setTime(startDate);
-
-		Calendar endDateCalendar = Calendar.getInstance();
-		endDateCalendar.setTime(endDate);
-
-		int startDateOffset = -(startDateCalendar.get(Calendar.ZONE_OFFSET) + startDateCalendar
-				.get(Calendar.DST_OFFSET))
-				/ (60 * 1000);
-
-		int endDateOffset = -(endDateCalendar.get(Calendar.ZONE_OFFSET) + endDateCalendar
-				.get(Calendar.DST_OFFSET))
-				/ (60 * 1000);
-
-		if (startDateOffset > endDateOffset) {
-			startDateCalendar.add(Calendar.MINUTE, endDateOffset
-					- startDateOffset);
-		}
+		int dateDiff = Days.daysBetween(new LocalDate(startDate), new LocalDate(endDate)).getDays();
 
 		if (inclusive) {
-			startDateCalendar.add(Calendar.DATE, -1);
+			dateDiff += dateDiff >= 0 ? 1 : -1;
 		}
-
-		int dateDiff = Integer.parseInt(DurationFormatUtils.formatDuration(
-				endDateCalendar.getTimeInMillis()
-						- startDateCalendar.getTimeInMillis(), "d", true));
 
 		return dateDiff;
 	}

--- a/rice-middleware/core/impl/src/main/java/org/kuali/rice/core/impl/datetime/DateTimeServiceImpl.java
+++ b/rice-middleware/core/impl/src/main/java/org/kuali/rice/core/impl/datetime/DateTimeServiceImpl.java
@@ -17,6 +17,8 @@ package org.kuali.rice.core.impl.datetime;
 
 import org.apache.commons.lang.StringUtils;
 import org.joda.time.DateTime;
+import org.joda.time.Days;
+import org.joda.time.LocalDate;
 import org.kuali.rice.core.api.CoreConstants;
 import org.kuali.rice.core.api.config.property.ConfigContext;
 import org.kuali.rice.core.api.datetime.DateTimeService;
@@ -28,7 +30,6 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
-import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;


### PR DESCRIPTION
Switched to Joda time to determine difference between dates
disregarding time zone and daylight savings time.